### PR TITLE
Replace rpi-sdimg IMAGE_FSTYPE with wks

### DIFF
--- a/meta-printnanny/recipes-core/images/printnanny-base.bb
+++ b/meta-printnanny/recipes-core/images/printnanny-base.bb
@@ -1,34 +1,15 @@
-include recipes-core/images/core-image-base.bb
+LICENSE = "AGPLv3"
+WKS_FILE = "sdimage-printnanny.wks"
+IMAGE_FEATURES += "splash ssh-server-openssh"
+IMAGE_FSTYPES = "ext4 ext4.xz wic.xz wic.bmap"
+SDIMG_ROOTFS_TYPE = "ext4.xz"
 
-COMPATIBLE_MACHINE = "^rpi$"
-
-WKS_FILE = "sdimage-printnanny-rpi.wks"
-IMAGE_FEATURES += "ssh-server-openssh"
-
-#
-# Customizations: meta-raspberrypi
-# https://github.com/agherzan/meta-raspberrypi/blob/master/docs/extra-build-config.md
-# v4l2 drivers
-VIDEO_CAMERA = "1"
-# RPI_USE_U_BOOT = "1"
-# DISABLE_RPI_BOOT_LOGO = "1"
-# INITRAMFS_IMAGE_BUNDLE = "1"
-# imx219 dt overlay
-RASPBERRYPI_CAMERA_V2 = "1"
-ENABLE_SPI_BUS = "1"
-ENABLE_I2C = "1"
-ENABLE_UART = "1"
-KERNEL_MODULE_AUTOLOAD:rpi += "i2c-dev i2c-bcm2708"
-
-# https://github.com/agherzan/meta-raspberrypi/blob/master/docs/extra-build-config.md
-IMAGE_FSTYPES = "ext4 ext4.xz rpi-sdimg"
-# IMAGE_FSTYPES = "ext4 ext4.xz"
-SDIMG_ROOTFS_TYPE = "ext4"
+inherit core-image
 
 #
 # Raspberry Pi Imager writes cloud-init cloud-config file to /boot/user-data
 #
-IMAGE_INSTALL:append = "cloud-init-systemd"
+# IMAGE_INSTALL:append = "cloud-init-systemd"
 
 # example fields written by Raspberry Pi Imager v1.7.2 
 #cloud-config

--- a/meta-printnanny/recipes-core/images/printnanny-rpi.bb
+++ b/meta-printnanny/recipes-core/images/printnanny-rpi.bb
@@ -1,0 +1,17 @@
+include recipes-core/images/printnanny-base.bb
+
+COMPATIBLE_MACHINE = "^(rpi|raspberrypi)"
+#
+# Customizations: meta-raspberrypi
+# https://github.com/agherzan/meta-raspberrypi/blob/master/docs/extra-build-config.md
+# v4l2 drivers
+VIDEO_CAMERA = "1"
+RPI_USE_U_BOOT = "1"
+# DISABLE_RPI_BOOT_LOGO = "1"
+# INITRAMFS_IMAGE_BUNDLE = "1"
+# imx219 dt overlay
+RASPBERRYPI_CAMERA_V2 = "1"
+ENABLE_SPI_BUS = "1"
+ENABLE_I2C = "1"
+ENABLE_UART = "1"
+KERNEL_MODULE_AUTOLOAD:rpi += "i2c-dev i2c-bcm2708"

--- a/meta-printnanny/wic/sdimage-printnanny-rpi.wks
+++ b/meta-printnanny/wic/sdimage-printnanny-rpi.wks
@@ -1,6 +1,0 @@
-# short-description: Create Raspberry Pi SD card image
-# long-description: Creates a partitioned SD card image for use with
-# Raspberry Pi. Boot files are located in the first vfat partition.
-
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 20 --fsoptions "defaults,flush" --use-uuid
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096 "defaults,noatime" --use-uuid

--- a/meta-printnanny/wic/sdimage-printnanny.wks
+++ b/meta-printnanny/wic/sdimage-printnanny.wks
@@ -1,0 +1,6 @@
+# short-description: Create Raspberry Pi SD card image
+# long-description: Creates a partitioned SD card image for use with
+# Raspberry Pi. Boot files are located in the first vfat partition.
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 20 --fsoptions "defaults,flush"
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096 --fsoptions "defaults,noatime"


### PR DESCRIPTION
This image class doesn't update /etc/fstab with boot partition.
https://github.com/agherzan/meta-raspberrypi/blob/master/classes/sdcard_image-rpi.bbclass

Instead, use OpenEmbedded Kickstart commands to create partition table + update fstab with `flush` (boot) and `noatime` (rootfs) options. https://docs.yoctoproject.org/ref-manual/kickstart.html