### PR TITLE
Fix cloudinit install quirks

### DIFF
--- a/conf/distro/bitsy.conf
+++ b/conf/distro/bitsy.conf
@@ -51,14 +51,9 @@ TCLIBCAPPEND = ""
 # meta-raspberrypi
 ENABLE_UART = "1"
 
-RPI_EXTRA_CONFIG = ' \n \
-    kernel=kernel8.img \
-    arm_64bit=1 \
-    '
-
 # Note also that Linux supports multiple consoles for output - but only one for input
 # the last named (or default if none named) from the kernel commandline specifies which is used for input, and all are used for output
-CMDLINE:append = "fsck.repair=yes systemd.unit=kernel-command-line.target systemd.show_status=1"
+CMDLINE:append = "fsck.repair=yes systemd.show_status=1"
 
 # Use systemd for system initialization
 DISTRO_FEATURES:append = " systemd"

--- a/meta-printnanny/conf/distro/printnanny.conf
+++ b/meta-printnanny/conf/distro/printnanny.conf
@@ -1,4 +1,9 @@
 require conf/distro/bitsy.conf
+
+DISTRO_FEATURES:append = "\
+    opencv \
+    tensorflow-lite \
+"
 DISTRO_EXTRA_RDEPENDS:append = "\
     packagegroup-printnanny-core \
     packagegroup-printnanny-sys \

--- a/meta-printnanny/conf/distro/printnanny.conf
+++ b/meta-printnanny/conf/distro/printnanny.conf
@@ -1,4 +1,7 @@
 require conf/distro/bitsy.conf
-DISTRO_EXTRA_RDEPENDS:append = "packagegroup-printnanny-core"
+DISTRO_EXTRA_RDEPENDS:append = "\
+    packagegroup-printnanny-core \
+    packagegroup-printnanny-sys \
+"
 VARIANT="PrintNanny Core Edition"
 VARIANT_ID="printnanny-core"

--- a/meta-printnanny/recipes-core/packagegroups/packagegroup-printnanny-core.bb
+++ b/meta-printnanny/recipes-core/packagegroups/packagegroup-printnanny-core.bb
@@ -5,10 +5,6 @@ PR = "r0"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
-LICENSE_FLAGS_ACCEPTED += "commercial_gstreamer1.0-omx"
-
 RDEPENDS:${PN} = "\
-    nnstreamer \
     printnanny-cli \
-    tensorflow-lite \
 "

--- a/meta-printnanny/recipes-core/packagegroups/packagegroup-printnanny-sys.bb
+++ b/meta-printnanny/recipes-core/packagegroups/packagegroup-printnanny-sys.bb
@@ -6,6 +6,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
+    cloud-init \
     cloud-init-systemd \
     dhcpcd \
     ntp \

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init/001-telemetry.cfg
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init/001-telemetry.cfg
@@ -1,4 +1,10 @@
 phone_home:
     url: https://printnanny.ai/api/cloudinit
-    post: all
+    post:
+        - pub_key_rsa
+        - pub_key_ecdsa
+        - pub_key_ed25519
+        - instance_id
+        - hostname
+        - fqdn
     tries: 10

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud.cfg
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud.cfg
@@ -72,3 +72,7 @@ system_info:
      shell: /bin/bash
    ntp_client: auto
    ssh_svcname: sshd.socket
+
+datasource:
+   NoCloud:
+     seedfrom: /boot/

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud.cfg
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud.cfg
@@ -73,6 +73,11 @@ system_info:
    ntp_client: auto
    ssh_svcname: sshd.socket
 
+# https://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html 
+# seed "NoCloud" datasource from /boot/user-data /boot/network-data, written by Raspberry Pi Imager
+
 datasource:
    NoCloud:
      seedfrom: /boot/
+
+ssh_genkeytypes: [rsa, ecdsa, ed25519]

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud.cfg
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud.cfg
@@ -74,10 +74,9 @@ system_info:
    ssh_svcname: sshd.socket
 
 # https://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html 
-# seed "NoCloud" datasource from /boot/user-data /boot/network-data, written by Raspberry Pi Imager
-
+# seed "NoCloud" datasource from /boot/user-data /boot/network-data (symlink) written by Raspberry Pi Imager
 datasource:
    NoCloud:
-     seedfrom: /boot/
+     seedfrom: /var/lib/cloud/seed/
 
 ssh_genkeytypes: [rsa, ecdsa, ed25519]

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init_%.bbappend
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init_%.bbappend
@@ -15,18 +15,14 @@ SRC_URI:append = "\
 "
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-# TODO
-# how to parameterize this recipe? I think BB variable -> environment variable -> do_install() renders jinja2 template makes sense
-# but given this requires installing python3native + native jinja + packaging j2cli, do this whenever a 2nd 3rd etc config variation is needed
-# maybe bitbake offers another mechanism to template files easily?
-# inherit python3native
-# DEPENDS = "python3-jinja2-native"
 
 do_install:append(){
+    install -d ${D}${sysconfdir}/cloud/cloud.cfg.d/
     install -d ${D}${sysconfdir}/cloud/cloud.cfg.d/
     install -d ${D}${bindir}
     ln -s /boot/user-data ${D}${sysconfdir}/cloud/cloud.cfg.d/001_user-data.cfg
     ln -s /boot/network-config ${D}${sysconfdir}/cloud/cloud.cfg.d/002_network-config.cfg
+    touch "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/meta-data"
     install -m 0644 ${WORKDIR}/cloud.cfg ${D}${sysconfdir}/cloud/cloud.cfg
     install -m 0644 ${WORKDIR}/001-telemetry.cfg ${D}${sysconfdir}/cloud/cloud.cfg.d/001-telemetry.cfg
     install -m 0644 ${WORKDIR}/002-ssh.cfg ${D}${sysconfdir}/cloud/cloud.cfg.d/002-ssh.cfg

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init_%.bbappend
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init_%.bbappend
@@ -1,9 +1,3 @@
-DESCRIPTION = "Customizable cfgs package to be used with cloud-init"
-HOMEPAGE = "https://github.com/canonical/cloud-init"
-SECTION = "devel/python"
-LICENSE = "AGPLv3+"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/AGPL-3.0-or-later;md5=a4af3f9f0c0fc9de318e4df46665906e"
-
 CLOUDINIT_TELEMETRY_URL ??= "https://printnanny.ai/api/cloudinit"
 CLOUDINIT_TELETRY_RETRY ??= "10"
 SRC_URI:append = "\

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init_%.bbappend
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init_%.bbappend
@@ -14,15 +14,20 @@ SRC_URI:append = "\
     file://printnanny-firstboot.sh \
 "
 
+# The name of the deploy directory for raspberry pi boot files.
+# This variable is referred to by recipes fetching / generating the files.
+BOOTFILES_DIR_NAME ?= "bootfiles"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 do_install:append(){
     install -d ${D}${sysconfdir}/cloud/cloud.cfg.d/
     install -d ${D}${sysconfdir}/cloud/cloud.cfg.d/
     install -d ${D}${bindir}
-    ln -s /boot/user-data ${D}${sysconfdir}/cloud/cloud.cfg.d/001_user-data.cfg
-    ln -s /boot/network-config ${D}${sysconfdir}/cloud/cloud.cfg.d/002_network-config.cfg
-    touch "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/meta-data"
+    install -d ${D}/var/lib/cloud/seed/
+    ln -s /boot/user-data ${D}/var/lib/cloud/seed/user-data
+    ln -s /boot/network-config ${D}/var/lib/cloud/seed/network-config
+    touch ${D}/var/lib/cloud/seed/meta-data
     install -m 0644 ${WORKDIR}/cloud.cfg ${D}${sysconfdir}/cloud/cloud.cfg
     install -m 0644 ${WORKDIR}/001-telemetry.cfg ${D}${sysconfdir}/cloud/cloud.cfg.d/001-telemetry.cfg
     install -m 0644 ${WORKDIR}/002-ssh.cfg ${D}${sysconfdir}/cloud/cloud.cfg.d/002-ssh.cfg

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init_%.bbappend
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init_%.bbappend
@@ -8,10 +8,6 @@ SRC_URI:append = "\
     file://printnanny-firstboot.sh \
 "
 
-# The name of the deploy directory for raspberry pi boot files.
-# This variable is referred to by recipes fetching / generating the files.
-BOOTFILES_DIR_NAME ?= "bootfiles"
-
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 do_install:append(){

--- a/meta-printnanny/recipes-multimedia/packagegroups/packagegroup-printnanny-multimedia.bb
+++ b/meta-printnanny/recipes-multimedia/packagegroups/packagegroup-printnanny-multimedia.bb
@@ -1,11 +1,14 @@
 SUMMARY = "PrintNanny Multimedia Packages"
 DESCRIPTION = "Minimal set of packages required to run PrintNanny Multimedia/Streaming stack"
+PR = "r0"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
-
+LICENSE_FLAGS_ACCEPTED += "commercial_gstreamer1.0-omx"
 RDEPENDS:${PN} = "\
+    nnstreamer \
     libcamera-apps \
     janus-gateway \
+    tensorflow-lite \
 "

--- a/recipes-extended/cloud-init/cloud-init_22.2.bb
+++ b/recipes-extended/cloud-init/cloud-init_22.2.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c6dd79b6ec2130a3364f6fa9d6380408"
 
-SRCREV = "b7debb9da63b356cc3cfb5ae2d8ba1f098884b28"
+SRCREV = "b6f3d691d352c2614074c6f528e71a4a011dc8e5"
 SRC_BRANCH = "bitsy-distro"
 SRC_URI = "git://github.com/bitsy-ai/cloud-init;branch=${SRC_BRANCH};protocol=https \
     file://cloud-init-source-local-lsb-functions.patch \
@@ -14,8 +14,15 @@ SRC_URI = "git://github.com/bitsy-ai/cloud-init;branch=${SRC_BRANCH};protocol=ht
 
 S = "${WORKDIR}/git"
 
-DISTUTILS_INSTALL_ARGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '--init-system=sysvinit_deb', '', d)}"
-DISTUTILS_INSTALL_ARGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '--init-system=systemd', '', d)}"
+SETUPTOOLS_INSTALL_ARGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '--init-system=sysvinit_deb', '', d)}"
+SETUPTOOLS_INSTALL_ARGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '--init-system=systemd', '', d)}"
+# --distro MUST not contain =, e.g. --distro=${DISTRO} is invalid
+# this is because cloud-init's setup.py parses sys.argv at the module level to render data files
+# https://github.com/canonical/cloud-init/blob/main/setup.py#L133
+# --distro=bitsy -> "--distro" in sys.argv == False
+# ---distro bitsy -> "--distro" in sys.argv == True
+# ¯\_(ツ)_/¯
+SETUPTOOLS_INSTALL_ARGS:append = " --distro ${DISTRO}"
 
 PV = "${@bb.parse.vars_from_file(d.getVar('FILE', False),d)[1] or '1.0'}-${SRC_BRANCH}+git${SRCPV}"
 
@@ -55,3 +62,36 @@ RDEPENDS:${PN} = "python3 \
                   python3-oauthlib \
                   bash \
                  "
+# overrides setuptools3_legacy bbclass to remove:
+# build --build-base=${B} install --skip-build ${SETUPTOOLS_INSTALL_ARGS}
+setuptools3_legacy_do_install() {
+        cd ${SETUPTOOLS_SETUP_PATH}
+        install -d ${D}${PYTHON_SITEPACKAGES_DIR}
+        STAGING_INCDIR=${STAGING_INCDIR} \
+        STAGING_LIBDIR=${STAGING_LIBDIR} \
+        PYTHONPATH=${D}${PYTHON_SITEPACKAGES_DIR} \
+        ${STAGING_BINDIR_NATIVE}/${PYTHON_PN}-native/${PYTHON_PN} setup.py \
+        install ${SETUPTOOLS_INSTALL_ARGS} || \
+        bbfatal_log "'${PYTHON_PN} setup.py install ${SETUPTOOLS_INSTALL_ARGS}' execution failed."
+
+        # support filenames with *spaces*
+        find ${D} -name "*.py" -exec grep -q ${D} {} \; \
+                               -exec sed -i -e s:${D}::g {} \;
+
+        for i in ${D}${bindir}/* ${D}${sbindir}/*; do
+            if [ -f "$i" ]; then
+                sed -i -e s:${PYTHON}:${USRBINPATH}/env\ ${SETUPTOOLS_PYTHON}:g $i
+                sed -i -e s:${STAGING_BINDIR_NATIVE}:${bindir}:g $i
+            fi
+        done
+
+        rm -f ${D}${PYTHON_SITEPACKAGES_DIR}/easy-install.pth
+
+        #
+        # FIXME: Bandaid against wrong datadir computation
+        #
+        if [ -e ${D}${datadir}/share ]; then
+            mv -f ${D}${datadir}/share/* ${D}${datadir}/
+            rmdir ${D}${datadir}/share
+        fi
+}

--- a/recipes-extended/cloud-init/cloud-init_22.2.bb
+++ b/recipes-extended/cloud-init/cloud-init_22.2.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c6dd79b6ec2130a3364f6fa9d6380408"
 
-SRCREV = "debed8d722e697fb21b4c0dcbbff0dc0de90b9df"
+SRCREV = "b7debb9da63b356cc3cfb5ae2d8ba1f098884b28"
 SRC_BRANCH = "bitsy-distro"
 SRC_URI = "git://github.com/bitsy-ai/cloud-init;branch=${SRC_BRANCH};protocol=https \
     file://cloud-init-source-local-lsb-functions.patch \

--- a/recipes-extended/cloud-init/cloud-init_22.2.bb
+++ b/recipes-extended/cloud-init/cloud-init_22.2.bb
@@ -64,7 +64,7 @@ RDEPENDS:${PN} = "python3 \
                  "
 # overrides setuptools3_legacy bbclass to remove:
 # build --build-base=${B} install --skip-build ${SETUPTOOLS_INSTALL_ARGS}
-setuptools3_legacy_do_install:${PN}() {
+setuptools3_legacy_do_install() {
         cd ${SETUPTOOLS_SETUP_PATH}
         install -d ${D}${PYTHON_SITEPACKAGES_DIR}
         STAGING_INCDIR=${STAGING_INCDIR} \

--- a/recipes-extended/cloud-init/cloud-init_22.2.bb
+++ b/recipes-extended/cloud-init/cloud-init_22.2.bb
@@ -64,7 +64,7 @@ RDEPENDS:${PN} = "python3 \
                  "
 # overrides setuptools3_legacy bbclass to remove:
 # build --build-base=${B} install --skip-build ${SETUPTOOLS_INSTALL_ARGS}
-setuptools3_legacy_do_install() {
+setuptools3_legacy_do_install:${PN}() {
         cd ${SETUPTOOLS_SETUP_PATH}
         install -d ${D}${PYTHON_SITEPACKAGES_DIR}
         STAGING_INCDIR=${STAGING_INCDIR} \


### PR DESCRIPTION
* Pass --distro to `setup.py install` - otherwise python3native install will detect host system distro for packaging/templating purposes
* Use /var/lib/cloud/seed/ to seed NoCloud datasource
* Needed to override setuptools3_legacy_do_install() to just call `setup.py install` - the default implementation invokes `setup.py build --skip-build install` for reasons I don't quite understand atm, but ¯\_(ツ)_/¯