### PR TITLE
Fix overlayfs-etc initialization

### DIFF
--- a/conf/distro/bitsy.conf
+++ b/conf/distro/bitsy.conf
@@ -71,7 +71,12 @@ ENABLE_UART = "1"
 
 # Note also that Linux supports multiple consoles for output - but only one for input
 # the last named (or default if none named) from the kernel commandline specifies which is used for input, and all are used for output
-CMDLINE:append = "fsck.repair=yes systemd.show_status=1 splash plymouth.ignore-serial-consoles"
+CMDLINE:append = "\
+    fsck.repair=yes \
+    systemd.show_status=1 \
+    splash \
+    ${@bb.utils.contains('OVERLAYFS_ETC_USE_ORIG_INIT_NAME', '0', 'init=/sbin/preinit', '', d)}
+"
 
 # Use systemd for system initialization
 DISTRO_FEATURES:append = " systemd"

--- a/conf/distro/bitsy.conf
+++ b/conf/distro/bitsy.conf
@@ -75,7 +75,7 @@ CMDLINE:append = "\
     fsck.repair=yes \
     systemd.show_status=1 \
     splash \
-    ${@bb.utils.contains('OVERLAYFS_ETC_USE_ORIG_INIT_NAME', '0', 'init=/sbin/preinit', '', d)}
+    ${@bb.utils.contains('OVERLAYFS_ETC_USE_ORIG_INIT_NAME', '0', 'init=/sbin/preinit', '', d)} \
 "
 
 # Use systemd for system initialization

--- a/conf/distro/bitsy.conf
+++ b/conf/distro/bitsy.conf
@@ -75,7 +75,6 @@ CMDLINE:append = "\
     fsck.repair=yes \
     systemd.show_status=1 \
     splash \
-    ${@bb.utils.contains('OVERLAYFS_ETC_USE_ORIG_INIT_NAME', '0', 'init=/sbin/preinit', '', d)} \
 "
 
 # Use systemd for system initialization

--- a/meta-printnanny/recipes-core/images/printnanny-core-image.bb
+++ b/meta-printnanny/recipes-core/images/printnanny-core-image.bb
@@ -18,6 +18,7 @@ IMAGE_FEATURES = "\
     splash \
     ssh-server-openssh \
 "
+
 # packagegroup-base (via packagegroup-base-extended) is required to pull in MACHINE_EXTRA_RRECOMMENDS
 # https://docs.yoctoproject.org/ref-manual/variables.html#term-MACHINE_EXTRA_RRECOMMENDS
 
@@ -33,6 +34,11 @@ IMAGE_INSTALL = "\
     ${CORE_IMAGE_EXTRA_INSTALL} \
 "
 
+CMDLINE:pn-rpi-cmdline:append = "\
+    testing=var \
+    ${@bb.utils.contains('IMAGE_FEATURES', 'overlayfs-etc', 'init=/sbin/preinit', '', d)} \
+"
+
 # COMBINED_FEATURES is the set of features enabled in MACHINE_FEATURES and DISTRO_FEATURES
 # COMBINED_FEATURES referenced in packagegroup-base to install base system packages
 MACHINE_FEATURES += "bluetooth wifi keyboard"
@@ -40,7 +46,6 @@ MACHINE_FEATURES += "bluetooth wifi keyboard"
 VOLATILE_LOG_DIR = "no"
 # disable splash
 # send boot messaegs to tty1
-CMDLINE:append = "console=tty1"
 # install empty-root-password, allow-empty-password, allow-root-login, post-install-logging
 inherit core-image
 

--- a/meta-printnanny/recipes-core/images/printnanny-core-image.bb
+++ b/meta-printnanny/recipes-core/images/printnanny-core-image.bb
@@ -34,11 +34,6 @@ IMAGE_INSTALL = "\
     ${CORE_IMAGE_EXTRA_INSTALL} \
 "
 
-CMDLINE:pn-rpi-cmdline:append = "\
-    testing=var \
-    ${@bb.utils.contains('IMAGE_FEATURES', 'overlayfs-etc', 'init=/sbin/preinit', '', d)} \
-"
-
 # COMBINED_FEATURES is the set of features enabled in MACHINE_FEATURES and DISTRO_FEATURES
 # COMBINED_FEATURES referenced in packagegroup-base to install base system packages
 MACHINE_FEATURES += "bluetooth wifi keyboard"

--- a/meta-printnanny/recipes-core/images/printnanny-core-image.bb
+++ b/meta-printnanny/recipes-core/images/printnanny-core-image.bb
@@ -6,6 +6,9 @@ WKS_FILE = "sdimage-printnanny.wks"
 # required to use both overlayfs-etc and package-management features
 # see note: https://git.yoctoproject.org/poky/plain/meta/classes/overlayfs-etc.bbclass
 OVERLAYFS_ETC_USE_ORIG_INIT_NAME = "0"
+OVERLAYFS_ETC_MOUNT_POINT = "/data"
+OVERLAYFS_ETC_DEVICE = "/dev/mmcblk0p2"
+OVERLAYFS_ETC_FSTYPE = "ext4"
 
 IMAGE_FEATURES = "\
     bash-completion-pkgs \
@@ -33,10 +36,6 @@ IMAGE_INSTALL = "\
 # COMBINED_FEATURES is the set of features enabled in MACHINE_FEATURES and DISTRO_FEATURES
 # COMBINED_FEATURES referenced in packagegroup-base to install base system packages
 MACHINE_FEATURES += "bluetooth wifi keyboard"
-
-OVERLAYFS_ETC_MOUNT_POINT = "/data"
-OVERLAYFS_ETC_DEVICE = "/dev/mmcblk0p2"
-OVERLAYFS_ETC_FSTYPE = "ext4"
 
 VOLATILE_LOG_DIR = "no"
 # disable splash

--- a/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,0 +1,5 @@
+# required to use both overlayfs-etc and package-management features
+# see note: https://git.yoctoproject.org/poky/plain/meta/classes/overlayfs-etc.bbclass
+CMDLINE:append = "\
+    init=/sbin/preinit \
+"


### PR DESCRIPTION
🎉 
```
root@raspberrypi4-64:~# df -h
Filesystem               Size  Used Avail Use% Mounted on
/dev/root                764M  394M  314M  56% /
devtmpfs                 3.8G     0  3.8G   0% /dev
/data/overlay-etc/upper  764M  394M  314M  56% /etc
tmpfs                    3.9G     0  3.9G   0% /dev/shm
tmpfs                    1.6G  9.0M  1.6G   1% /run
tmpfs                    4.0M     0  4.0M   0% /sys/fs/cgroup
tmpfs                    3.9G     0  3.9G   0% /tmp
tmpfs                    3.9G  168K  3.9G   1% /var/volatile
/dev/mmcblk0p1            71M   46M   26M  65% /boot
```