### PR TITLE
Service ordering of cloud-init, printnanny-generator, nginx is working

### DIFF
--- a/meta-printnanny/recipes-core/printnanny-apps/files/Rocket.toml
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/Rocket.toml
@@ -2,6 +2,6 @@
 [default]
 address = "127.0.0.1"
 port = 9001
-template_dir = "/usr/share/printnanny/wwww"
+template_dir = "/usr/share/printnanny/www"
 workers = 2
 log_level = "normal"

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-dash.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-dash.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=PrintNanny Dashboard
-After=network.target network-online.target
-Wants=network.target network-online.target
+After=network.target network-online.target cloud-config.target
+Wants=network.target network-online.target cloud-config.target
 PartOf=printnanny-online.target
 ReloadPropagatedFrom=printnanny-online.target printnanny.target
 

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-dash.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-dash.service
@@ -8,13 +8,11 @@ ReloadPropagatedFrom=printnanny-online.target printnanny.target
 [Service]
 Type=simple
 SyslogIdentifier=printnanny-dash
-EnvironmentFile=-printnanny
 ExecStart=/bin/bash -c "ROCKET_SECRET_KEY=$(cat ${CREDENTIALS_DIRECTORY}/cookie-secret) \
     ROCKET_CONFIG=/etc/printnanny/dash/Rocket.toml \
     JANUS_EDGE_ADMIN_SECRET_FILE=${CREDENTIALS_DIRECTORY}/janus-edge-admin-secret \
     JANUS_EDGE_API_TOKEN_FILE=${CREDENTIALS_DIRECTORY}/janus-edge-api-token \
     /usr/bin/printnanny-dash"
-User=printnanny
 Restart=on-failure
 RestartSec=30
 

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-dash.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-dash.service
@@ -9,11 +9,11 @@ ReloadPropagatedFrom=printnanny-online.target printnanny.target
 Type=simple
 SyslogIdentifier=printnanny-dash
 EnvironmentFile=-printnanny
-ExecStart=ROCKET_SECRET_KEY=$(cat ${CREDENTIALS_DIRECTORY}/cookie-secret) \
+ExecStart=/bin/bash -c "ROCKET_SECRET_KEY=$(cat ${CREDENTIALS_DIRECTORY}/cookie-secret) \
     ROCKET_CONFIG=/etc/printnanny/dash/Rocket.toml \
     JANUS_EDGE_ADMIN_SECRET_FILE=${CREDENTIALS_DIRECTORY}/janus-edge-admin-secret \
     JANUS_EDGE_API_TOKEN_FILE=${CREDENTIALS_DIRECTORY}/janus-edge-api-token \
-    /usr/bin/printnanny-dash
+    /usr/bin/printnanny-dash"
 User=printnanny
 Restart=on-failure
 RestartSec=30

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
@@ -2,25 +2,31 @@
 
 set -euo pipefail
 
-COOKIE_SECRET=$(openssl rand -base64 32)
-JANUS_ADMIN=$(openssl rand -base64 32)
-JANUS_API_TOKEN=$(openssl rand -base64 32) 
-
-echo -n "$COOKIE_SECRET" | systemd-creds encrypt --name cookie-secret -p - - > "/etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
-echo "Created /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
-echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - > "/etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
-echo "Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
-echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - > "/etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
-echo "Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
-
-mkdir -p /etc/systemd/system/janus-gateway.d/
-echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - > "/etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
-echo "Created /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
-echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - > "/etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
-echo "Created /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
-
 
 if [ "$SYSTEMD_FIRST_BOOT" == "1"]; then
+    COOKIE_SECRET=$(openssl rand -base64 32)
+    JANUS_ADMIN=$(openssl rand -base64 32)
+    JANUS_API_TOKEN=$(openssl rand -base64 32) 
+
+    echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf
+    echo -n "$COOKIE_SECRET" | systemd-creds encrypt --name cookie-secret -p - - >> "/etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
+    echo "Created /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
+
+    echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf
+    echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "/etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
+    echo "Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
+
+    echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf
+    echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "/etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
+    echo "Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
+
+    echo "[Unit]" > /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf
+    echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "/etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
+    echo "Created /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
+
+    echo "[Unit]" > /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf
+    echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "/etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
+    echo "Created /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
     echo "Initializing printnanny config"
     /usr/bin/printnanny config init --output=/etc/printnanny/default.toml
     mkdir -p /etc/printnanny/keys

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
@@ -5,27 +5,25 @@ set -euo pipefail
 COOKIE_SECRET=$(openssl rand -base64 32)
 JANUS_ADMIN=$(openssl rand -base64 32)
 JANUS_API_TOKEN=$(openssl rand -base64 32) 
-NOW=$(date '+%s')
 
-mkdir -p /etc/systemd/system/printnanny-dash.d/
-echo -n "$COOKIE_SECRET" | systemd-creds encrypt --name cookie-secret -p - - > "/etc/systemd/system/printnanny-dash.d/${NOW}-cookie-secret.conf"
-echo "Created /etc/systemd/system/printnanny-dash.d/${NOW}-cookie-secret.conf"
-echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - > "/etc/systemd/system/printnanny-dash.d/${NOW}-janus-edge-admin-secret.conf"
-echo "Created /etc/systemd/system/printnanny-dash.d/${NOW}-janus-edge-admin-secret.conf"
-echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - > "/etc/systemd/system/printnanny-dash/${NOW}-janus-edge-api-token.conf"
-echo "Created /etc/systemd/system/printnanny-dash/${NOW}-janus-edge-api-token.conf"
+echo -n "$COOKIE_SECRET" | systemd-creds encrypt --name cookie-secret -p - - > "/etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
+echo "Created /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
+echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - > "/etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
+echo "Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
+echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - > "/etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
+echo "Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
 
 mkdir -p /etc/systemd/system/janus-gateway.d/
-echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - > "/etc/systemd/system/janus-gateway.d/${NOW}-janus-edge-admin-secret.conf"
-echo "Created /etc/systemd/system/janus-gateway.d/${NOW}-janus-edge-admin-secret.conf"
-echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - > "/etc/systemd/system/janus-gateway.d/${NOW}-janus-edge-api-token.conf"
-echo "Created /etc/systemd/system/janus-gateway.d/${NOW}-janus-edge-api-token.conf"
+echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - > "/etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
+echo "Created /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
+echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - > "/etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
+echo "Created /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
 
 
 if [ "$SYSTEMD_FIRST_BOOT" == "1"]; then
     echo "Initializing printnanny config"
     /usr/bin/printnanny config init --output=/etc/printnanny/default.toml
-    mkdir -p --output=/etc/printnanny/keys
+    mkdir -p /etc/printnanny/keys
     /usr/bin/printnanny config generate-keys --output=/etc/printnanny/keys
 else
     echo "Skipping printnanny config init, SYSTEMD_FIRST_BOOT=$SYSTEMD_FIRST_BOOT"

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
@@ -57,7 +57,7 @@ else
 fi
 
 
-if [ -f "$PRINTNANNY_CONF_FILE" ]; then
+if [ -f "$PRINTNANNY_KEYS" ]; then
     echo "<6>printnanny-generator[$$]: $PRINTNANNY_KEYS exists, skipping key generation"
 else
     mkdir -p "$PRINTNANNY_KEYS"

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
@@ -2,36 +2,63 @@
 
 set -euo pipefail
 
+# cookie secret is used by printnanny-dash to encrypt cookie data
+COOKIE_SECRET_FILE="/etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
 
-if [ "$SYSTEMD_FIRST_BOOT" == "1"]; then
-    COOKIE_SECRET=$(openssl rand -base64 32)
-    JANUS_ADMIN=$(openssl rand -base64 32)
-    JANUS_API_TOKEN=$(openssl rand -base64 32) 
+# janus adin secret/token is required by printnanny-dash, janus-gateway, and octoprint
+JANUS_ADMIN_FILE="/etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
+JANUS_ADMIN_DASH_LN="/etc/systemd/system/printnanny-dash.service./janus-edge-admin-secret.conf"
+JANUS_TOKEN_FILE="/etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
+JANUS_TOKEN_DASH_LN="/etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
 
-    echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf
-    echo -n "$COOKIE_SECRET" | systemd-creds encrypt --name cookie-secret -p - - >> "/etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
-    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf" > /dev/kmsg
+# default PrintNannyConfig file
+PRINTNANNY_CONF_FILE="/etc/printnanny/default.toml"
+PRINTNANNY_KEYS="/etc/printnanny/keys"
 
-    echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf
-    echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "/etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
-    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf" > /dev/kmsg
-
-    echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf
-    echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "/etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
-    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf" > /dev/kmsg
-
-    echo "[Unit]" > /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf
-    echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "/etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
-    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf" > /dev/kmsg
-
-    echo "[Unit]" > /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf
-    echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "/etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
-    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf" > /dev/kmsg
-    /usr/bin/printnanny config init --output=/etc/printnanny/default.toml
-    mkdir -p /etc/printnanny/keys
-    echo "<4>printnanny-generator[$$]: Initialized printnanny config /etc/printnanny/default.toml" > /dev/kmsg
-    /usr/bin/printnanny config generate-keys --output=/etc/printnanny/keys
-
+if [ -f "$COOKIE_SECRET_FILE" ]; then
+    echo "<6>printnanny-generator[$$]: $COOKIE_SECRET_FILE exists, skipping credential generation"
 else
-    echo "<4>printnanny-generator[$$]: Skipping printnanny-generator, SYSTEMD_FIRST_BOOT=$SYSTEMD_FIRST_BOOT" > /dev/kmsg
+    SECRET=$(openssl rand -base64 32)
+    echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf
+    echo -n "$SECRET" | systemd-creds encrypt --name cookie-secret -p - - >> "$COOKIE_SECRET_FILE"
+    echo "<4>printnanny-generator[$$]: Created $COOKIE_SECRET_FILE" > /dev/kmsg
+fi
+
+
+if [ -f "$JANUS_ADMIN_FILE" ]; then
+    echo "<6>printnanny-generator[$$]: $JANUS_ADMIN_FILE exists, skipping credential generation"
+else
+    SECRET=$(openssl rand -base64 32)
+    echo "[Unit]" > "$JANUS_ADMIN_FILE"
+    echo -n "$SECRET" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "$JANUS_ADMIN_FILE"
+    echo "<4>printnanny-generator[$$]: Created $JANUS_ADMIN_FILE" > /dev/kmsg
+    ln -s "$JANUS_ADMIN_FILE" "$JANUS_ADMIN_DASH_LN"
+    echo "<4>printnanny-generator[$$]: Created link from $JANUS_ADMIN_FILE to $JANUS_ADMIN_DASH_LN"
+fi
+
+if [ -f "$JANUS_TOKEN_FILE" ]; then
+    echo "<6>printnanny-generator[$$]: $JANUS_TOKEN_FILE exists, skipping credential generation"
+else
+    SECRET=$(openssl rand -base64 32)
+    echo "[Unit]" > "$JANUS_TOKEN_FILE"
+    echo -n "$SECRET" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "$JANUS_TOKEN_FILE"
+    echo "<4>printnanny-generator[$$]: Created $JANUS_TOKEN_FILE" > /dev/kmsg
+    ln -s "$JANUS_TOKEN_FILE" "$JANUS_TOKEN_DASH_LN"
+    echo "<4>printnanny-generator[$$]: Created link from $JANUS_TOKEN_FILE to $JANUS_TOKEN_DASH_LN"
+fi
+
+if [ -f "$PRINTNANNY_CONF_FILE" ]; then
+    echo "<6>printnanny-generator[$$]: $PRINTNANNY_CONF_FILE exists, skipping config generation"
+else
+    /usr/bin/printnanny config init --output="$PRINTNANNY_CONF_FILE"
+    echo "<4>printnanny-generator[$$]: Created config $PRINTNANNY_CONF_FILE"
+fi
+
+
+if [ -f "$PRINTNANNY_CONF_FILE" ]; then
+    echo "<6>printnanny-generator[$$]: $PRINTNANNY_KEYS exists, skipping key generation"
+else
+    mkdir -p "$PRINTNANNY_KEYS"
+    /usr/bin/printnanny config generate-keys --output="$PRINTNANNY_KEYS"
+    echo "<4>printnanny-generator[$$]: Generated keys $PRINTNANNY_KEYS"
 fi

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
@@ -7,7 +7,7 @@ COOKIE_SECRET_FILE="/etc/systemd/system/printnanny-dash.service.d/cookie-secret.
 
 # janus adin secret/token is required by printnanny-dash, janus-gateway, and octoprint
 JANUS_ADMIN_FILE="/etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
-JANUS_ADMIN_DASH_LN="/etc/systemd/system/printnanny-dash.service./janus-edge-admin-secret.conf"
+JANUS_ADMIN_DASH_LN="/etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
 JANUS_TOKEN_FILE="/etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
 JANUS_TOKEN_DASH_LN="/etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
 
@@ -29,6 +29,7 @@ if [ -f "$JANUS_ADMIN_FILE" ]; then
     echo "<6>printnanny-generator[$$]: $JANUS_ADMIN_FILE exists, skipping credential generation"
 else
     SECRET=$(openssl rand -base64 32)
+    mkdir -p /etc/systemd/system/janus-gateway.service.d/
     echo "[Service]" > "$JANUS_ADMIN_FILE"
     echo -n "$SECRET" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "$JANUS_ADMIN_FILE"
     echo "<4>printnanny-generator[$$]: Created $JANUS_ADMIN_FILE" > /dev/kmsg
@@ -40,6 +41,7 @@ if [ -f "$JANUS_TOKEN_FILE" ]; then
     echo "<6>printnanny-generator[$$]: $JANUS_TOKEN_FILE exists, skipping credential generation"
 else
     SECRET=$(openssl rand -base64 32)
+    mkdir -p /etc/systemd/system/janus-gateway.service.d/
     echo "[Service]" > "$JANUS_TOKEN_FILE"
     echo -n "$SECRET" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "$JANUS_TOKEN_FILE"
     echo "<4>printnanny-generator[$$]: Created $JANUS_TOKEN_FILE" > /dev/kmsg

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
@@ -10,27 +10,28 @@ if [ "$SYSTEMD_FIRST_BOOT" == "1"]; then
 
     echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf
     echo -n "$COOKIE_SECRET" | systemd-creds encrypt --name cookie-secret -p - - >> "/etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
-    echo "Created /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf"
+    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf" > /dev/kmsg
 
     echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf
     echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "/etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
-    echo "Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf"
+    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-admin-secret.conf" > /dev/kmsg
 
     echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf
     echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "/etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
-    echo "Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf"
+    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/printnanny-dash.service.d/janus-edge-api-token.conf" > /dev/kmsg
 
     echo "[Unit]" > /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf
     echo -n "$JANUS_ADMIN" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "/etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
-    echo "Created /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf"
+    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/janus-gateway.service.d/janus-edge-admin-secret.conf" > /dev/kmsg
 
     echo "[Unit]" > /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf
     echo -n "$JANUS_API_TOKEN" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "/etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
-    echo "Created /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf"
-    echo "Initializing printnanny config"
+    echo "<4>printnanny-generator[$$]: Created /etc/systemd/system/janus-gateway.service.d/janus-edge-api-token.conf" > /dev/kmsg
     /usr/bin/printnanny config init --output=/etc/printnanny/default.toml
     mkdir -p /etc/printnanny/keys
+    echo "<4>printnanny-generator[$$]: Initialized printnanny config /etc/printnanny/default.toml" > /dev/kmsg
     /usr/bin/printnanny config generate-keys --output=/etc/printnanny/keys
+
 else
-    echo "Skipping printnanny config init, SYSTEMD_FIRST_BOOT=$SYSTEMD_FIRST_BOOT"
+    echo "<4>printnanny-generator[$$]: Skipping printnanny-generator, SYSTEMD_FIRST_BOOT=$SYSTEMD_FIRST_BOOT" > /dev/kmsg
 fi

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
@@ -19,7 +19,7 @@ if [ -f "$COOKIE_SECRET_FILE" ]; then
     echo "<6>printnanny-generator[$$]: $COOKIE_SECRET_FILE exists, skipping credential generation"
 else
     SECRET=$(openssl rand -base64 32)
-    echo "[Unit]" > /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf
+    echo "[Service]" > /etc/systemd/system/printnanny-dash.service.d/cookie-secret.conf
     echo -n "$SECRET" | systemd-creds encrypt --name cookie-secret -p - - >> "$COOKIE_SECRET_FILE"
     echo "<4>printnanny-generator[$$]: Created $COOKIE_SECRET_FILE" > /dev/kmsg
 fi
@@ -29,7 +29,7 @@ if [ -f "$JANUS_ADMIN_FILE" ]; then
     echo "<6>printnanny-generator[$$]: $JANUS_ADMIN_FILE exists, skipping credential generation"
 else
     SECRET=$(openssl rand -base64 32)
-    echo "[Unit]" > "$JANUS_ADMIN_FILE"
+    echo "[Service]" > "$JANUS_ADMIN_FILE"
     echo -n "$SECRET" | systemd-creds encrypt --name janus-edge-admin-secret -p - - >> "$JANUS_ADMIN_FILE"
     echo "<4>printnanny-generator[$$]: Created $JANUS_ADMIN_FILE" > /dev/kmsg
     ln -s "$JANUS_ADMIN_FILE" "$JANUS_ADMIN_DASH_LN"
@@ -40,7 +40,7 @@ if [ -f "$JANUS_TOKEN_FILE" ]; then
     echo "<6>printnanny-generator[$$]: $JANUS_TOKEN_FILE exists, skipping credential generation"
 else
     SECRET=$(openssl rand -base64 32)
-    echo "[Unit]" > "$JANUS_TOKEN_FILE"
+    echo "[Service]" > "$JANUS_TOKEN_FILE"
     echo -n "$SECRET" | systemd-creds encrypt --name janus-edge-api-token -p - - >> "$JANUS_TOKEN_FILE"
     echo "<4>printnanny-generator[$$]: Created $JANUS_TOKEN_FILE" > /dev/kmsg
     ln -s "$JANUS_TOKEN_FILE" "$JANUS_TOKEN_DASH_LN"

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-mqtt.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-mqtt.service
@@ -9,10 +9,8 @@ ReloadPropagatedFrom=printnanny-online.target
 Type=simple
 SyslogIdentifier=printnanny-mqtt
 RuntimeDirectory=printnanny
-RuntimeDirectoryPreserve=yes
 ConfigurationDirectory=printnanny
 ExecStart=/usr/bin/printnanny -v event subscribe
-User=printnanny
 Restart=on-failure
 RestartSec=30
 

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-mqtt.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-mqtt.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=PrintNanny MQTT Client
-After=network.target network-online.target
-Wants=network.target network-online.target
+After=network.target network-online.target cloud-config.target
+Wants=network.target network-online.target cloud-config.target
 PartOf=printnanny-online.target
 ReloadPropagatedFrom=printnanny-online.target
 

--- a/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
+++ b/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
@@ -27,6 +27,9 @@ do_install() {
   install -d "${D}${sysconfdir}/printnanny/dash"
   install -d "${D}${sysconfdir}/printnanny/printnanny.d"
   install -d "${D}${systemd_unitdir}/system-generators"
+  install -d "${D}${sysconfdir}/systemd/system/printnanny-dash.service.d"
+  install -d "${D}${sysconfdir}/systemd/system/printnanny-mqtt.service.d"
+
   cp -R --no-dereference --preserve=mode,links -v "${WORKDIR}/www" "${D}${datadir}/printnanny"
   install -m 0644 "${WORKDIR}/printnanny-dash.service" "${D}${systemd_system_unitdir}/printnanny-dash.service"
   install -m 0644 "${WORKDIR}/Rocket.toml" "${D}${sysconfdir}/printnanny/dash/Rocket.toml"

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud.cfg
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud.cfg
@@ -86,7 +86,13 @@ system_info:
    distro: bitsy
    network:
       renderers: ['netplan', 'network-manager', 'networkd', 'eni']
-
+   default_user:
+     name: printnanny
+     lock_passwd: True
+     gecos: PrintNanny
+     groups: [adm, audio, dialout, gpio, i2c, input, netdev, plugdev, spi, sudo, video]
+     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+     shell: /bin/bash
 power_state:
    mode: reboot
    message: Rebooting to apply custom settings

--- a/meta-printnanny/recipes-httpd/nginx/nginx/dash.locations.template
+++ b/meta-printnanny/recipes-httpd/nginx/nginx/dash.locations.template
@@ -1,0 +1,18 @@
+location /printnanny-cloud/ {
+    resolver 8.8.8.8;
+    proxy_pass $PRINTNANNY_API_URL/;
+}
+
+location / {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_pass              http://127.0.0.1:9001/; # make sure to add trailing slash here!
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_send_timeout 300; 
+}

--- a/meta-printnanny/recipes-httpd/nginx/nginx/nginx.service
+++ b/meta-printnanny/recipes-httpd/nginx/nginx/nginx.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The NGINX HTTP and reverse proxy server
-After=syslog.target network.target remote-fs.target nss-lookup.target
+After=syslog.target network.target remote-fs.target nss-lookup.target cloud-config.target
 
 [Service]
 Type=forking

--- a/meta-printnanny/recipes-httpd/nginx/nginx/nginx.service
+++ b/meta-printnanny/recipes-httpd/nginx/nginx/nginx.service
@@ -11,6 +11,9 @@ ExecStart=/usr/sbin/nginx
 ExecReload=/usr/sbin/nginx -s reload
 ExecStop=/bin/kill -s QUIT $MAINPID
 PrivateTmp=true
+Restart=on-failure
+Restart=on-failure
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-printnanny/recipes-httpd/nginx/nginx/octoprint.locations.template
+++ b/meta-printnanny/recipes-httpd/nginx/nginx/octoprint.locations.template
@@ -1,0 +1,15 @@
+location /octoprint/ {
+    proxy_pass http://127.0.0.1:5001/; # make sure to add trailing slash here!
+    proxy_set_header Host $http_host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Scheme $scheme;
+    proxy_set_header X-Script-Name /octoprint;
+    proxy_http_version 1.1;
+    client_max_body_size 1G;
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_send_timeout 300; 
+}

--- a/meta-printnanny/recipes-httpd/nginx/nginx/server.conf.template
+++ b/meta-printnanny/recipes-httpd/nginx/nginx/server.conf.template
@@ -7,43 +7,8 @@ server {
     proxy_buffers 2 512k;
     proxy_buffer_size 256k;
     error_log stderr info;
+    rewrite_log on;
     access_log /var/log/nginx.log;
     error_log /var/log/nginx.error info;
     proxy_cookie_domain localhost $host;
-
-
-    location /octoprint/ {
-        proxy_pass http://127.0.0.1:5001/; # make sure to add trailing slash here!
-        proxy_set_header Host $http_host;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Scheme $scheme;
-        proxy_set_header X-Script-Name /octoprint;
-        proxy_http_version 1.1;
-        client_max_body_size 1G;
-        proxy_read_timeout 300;
-        proxy_connect_timeout 300;
-        proxy_send_timeout 300; 
-    }
-
-    location / {
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header        Host $host;
-        proxy_set_header        X-Real-IP $remote_addr;
-        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Proto $scheme;
-        proxy_pass              http://127.0.0.1:9001/; # make sure to add trailing slash here!
-        proxy_read_timeout 300;
-        proxy_connect_timeout 300;
-        proxy_send_timeout 300; 
-    }
-
-    location /printnanny-cloud/ {
-        resolver 8.8.8.8;
-        proxy_pass $PRINTNANNY_API_URL/;
-    }
 }

--- a/meta-printnanny/recipes-httpd/nginx/nginx/server.conf.template
+++ b/meta-printnanny/recipes-httpd/nginx/nginx/server.conf.template
@@ -1,7 +1,7 @@
 server {
     listen 80;
     listen [::]:80;
-    server_name $hostname;
+    server_name $hostname *.local;
     include /etc/nginx/conf.d/*.locations;
     proxy_busy_buffers_size 512k;
     proxy_buffers 2 512k;

--- a/meta-printnanny/recipes-httpd/nginx/nginx_%.bbappend
+++ b/meta-printnanny/recipes-httpd/nginx/nginx_%.bbappend
@@ -3,12 +3,16 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI += "\
     file://nginx-envsubst-on-templates.sh \
     file://server.conf.template \
+    file://dash.locations.template \
+    file://octoprint.locations.template \
 "
 
 do_install:append(){
   install -d "${D}${bindir}"
   install -d "${D}${sysconfdir}/nginx/templates"
   install -m 0644 "${WORKDIR}/server.conf.template" "${D}${sysconfdir}/nginx/templates/server.conf.template"
+  install -m 0644 "${WORKDIR}/dash.locations.template" "${D}${sysconfdir}/nginx/templates/dash.locations.template"
+  install -m 0644 "${WORKDIR}/octoprint.locations.template" "${D}${sysconfdir}/nginx/templates/octoprint.locations.template"
   install -m 0755 "${WORKDIR}/nginx-envsubst-on-templates.sh" "${D}${bindir}/nginx-envsubst-on-templates"
   install -m 0644 "${WORKDIR}/nginx.service" "${D}${systemd_system_unitdir}/nginx.service"
 }

--- a/recipes-core/bitsy-tweaks/files/getty@tty1.service.d/50-noclear.conf
+++ b/recipes-core/bitsy-tweaks/files/getty@tty1.service.d/50-noclear.conf
@@ -1,2 +1,4 @@
+[Unit]
+After=cloud-init-local.service
 [Service]
 TTYVTDisallocate=no

--- a/recipes-extended/cloud-init/cloud-init_22.2.bb
+++ b/recipes-extended/cloud-init/cloud-init_22.2.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c6dd79b6ec2130a3364f6fa9d6380408"
 
-SRCREV = "0d65da29963511fbd772b62129645cef277b84cd"
+SRCREV = "01d8cd38fef120105ad459591361b4aad746ae96"
 SRC_BRANCH = "bitsy-distro"
 SRC_URI = "git://github.com/bitsy-ai/cloud-init;branch=${SRC_BRANCH};protocol=https \
     file://cloud-init-source-local-lsb-functions.patch \

--- a/recipes-extended/cloud-init/cloud-init_22.2.bb
+++ b/recipes-extended/cloud-init/cloud-init_22.2.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c6dd79b6ec2130a3364f6fa9d6380408"
 
-SRCREV = "01d8cd38fef120105ad459591361b4aad746ae96"
+SRCREV = "46aa12ec7f76f1e6173d0816fb09f44fbcbefbfb"
 SRC_BRANCH = "bitsy-distro"
 SRC_URI = "git://github.com/bitsy-ai/cloud-init;branch=${SRC_BRANCH};protocol=https \
     file://cloud-init-source-local-lsb-functions.patch \

--- a/recipes-multimedia/janus-gateway/janus-gateway_0.11.8.bb
+++ b/recipes-multimedia/janus-gateway/janus-gateway_0.11.8.bb
@@ -34,6 +34,7 @@ PACKAGECONFIGF[websockets] = "--enable-websockets,--disable-websockets,libwebsoc
 do_install:append() {
 	install -d ${D}${systemd_unitdir}/system
 	install -m 644 ${WORKDIR}/janus-gateway.service ${D}${systemd_unitdir}/system/
+	install -d "${D}${sysconfdir}/systemd/system/janus-gateway.service.d"
 }
 
 FILES:${PN} += "${nonarch_libdir}/janus/plugins/ ${libdir}/janus/transports ${libdir}/janus/events"


### PR DESCRIPTION
2fa flow is currently failing with the following error, will tackle that in the next PR.
```
Jun 07 15:47:22 pn-05-24 printnanny-dash[654]: Reading public key from "/etc/printnanny/keys/ec_public.pem"
Jun 07 15:47:22 pn-05-24 printnanny-dash[654]: Error: Error de/serializing content IoError(Os { code: 2, kind: NotFound, message: "No such file or directory" })
Jun 07 15:47:22 pn-05-24 printnanny-dash[654]:    >> Outcome: Success
Jun 07 15:47:22 pn-05-24 printnanny-dash[654]:    >> Response succeeded.
```