### PR TITLE
Remove separator to resolve unhandled multipart error from cloud-init

### DIFF
--- a/recipes-bsp/bootfiles/files/vendor-data.yaml
+++ b/recipes-bsp/bootfiles/files/vendor-data.yaml
@@ -1,4 +1,3 @@
----
 merge_how:
   - name: list
     settings: [append]


### PR DESCRIPTION
Should fix the following warning during first boot:
```
[   31.099531] cloud-init[450]: 2022-05-24 21:33:01,334 - __init__.py[WARNING]: Unhandled non-multipart (text/x-not-multipart) userdata: 'b'---'...'
```