### PR TITLE
Rm default.toml config generator

### DIFF
--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-generator.sh
@@ -53,14 +53,6 @@ else
     echo "<4>printnanny-generator[$$]: Created link from $JANUS_TOKEN_FILE to $JANUS_TOKEN_OCTOPRINT_LN"
 fi
 
-if [ -f "$PRINTNANNY_CONF_FILE" ]; then
-    echo "<6>printnanny-generator[$$]: $PRINTNANNY_CONF_FILE exists, skipping config generation"
-else
-    /usr/bin/printnanny config init --output="$PRINTNANNY_CONF_FILE"
-    echo "<4>printnanny-generator[$$]: Created config $PRINTNANNY_CONF_FILE"
-fi
-
-
 if [ -f "$PRINTNANNY_KEYS" ]; then
     echo "<6>printnanny-generator[$$]: $PRINTNANNY_KEYS exists, skipping key generation"
 else

--- a/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
+++ b/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
@@ -8,6 +8,7 @@ SRC_URI = " \
     file://printnanny-license.service \
     file://printnanny-mqtt.service \
     file://printnanny-online.target \
+    file://printnanny-generator.sh \
     file://Rocket.toml \
     file://dev.toml \
 "
@@ -29,6 +30,7 @@ do_install() {
   install -m 0644 "${WORKDIR}/printnanny-license.service" "${D}${systemd_system_unitdir}/printnanny-license.service"
   install -m 0644 "${WORKDIR}/printnanny-mqtt.service" "${D}${systemd_system_unitdir}/printnanny-mqtt.service"
   install -m 0644 "${WORKDIR}/printnanny-online.target" "${D}${systemd_system_unitdir}/printnanny-online.target"
+  install -m 0755 "${WORKDIR}/printnanny-generator.sh" "${D}${systemd_unitdir}/system-generators/printnanny-generator"
   install -m 0755 "${WORKDIR}/dev.toml" "${D}${sysconfdir}/printnanny"
 }
 

--- a/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
+++ b/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
@@ -8,7 +8,6 @@ SRC_URI = " \
     file://printnanny-license.service \
     file://printnanny-mqtt.service \
     file://printnanny-online.target \
-    file://printnanny-generator.sh \
     file://Rocket.toml \
     file://dev.toml \
 "
@@ -30,7 +29,6 @@ do_install() {
   install -m 0644 "${WORKDIR}/printnanny-license.service" "${D}${systemd_system_unitdir}/printnanny-license.service"
   install -m 0644 "${WORKDIR}/printnanny-mqtt.service" "${D}${systemd_system_unitdir}/printnanny-mqtt.service"
   install -m 0644 "${WORKDIR}/printnanny-online.target" "${D}${systemd_system_unitdir}/printnanny-online.target"
-  install -m 0755 "${WORKDIR}/printnanny-generator.sh" "${D}${systemd_unitdir}/system-generators/printnanny-generator"
   install -m 0755 "${WORKDIR}/dev.toml" "${D}${sysconfdir}/printnanny"
 }
 


### PR DESCRIPTION
It's not necessary to write default config out to file, since the default values are supplied by Rust's Default trait. 

Currently, the config is getting written out before cloud-init changes the hostname of the machine. Let's not
```
root@pn-octo:~# cat /etc/printnanny/default.toml
[printnanny_cloud_proxy]
hostname = 'raspberrypi4-64'
base_path = '/printnanny-cloud'
url = 'http://raspberrypi4-64/printnanny-cloud'

[paths]
etc = '/etc/printnanny'
confd = '/etc/printnanny/conf.d'
events_socket = '/var/run/printnanny/events.socket'
issue_txt = '/boot/issue.txt'
log = '/var/log/printnanny'
octoprint = '/home/octoprint/.octoprint'
run = '/var/run/printnanny'

[api]
base_path = 'https://printnanny.ai'
static_url = 'https://printnanny.ai/static/'
dashboard_url = 'https://printnanny.ai/dashboard/'

[dash]
base_url = 'http://raspberrypi4-64/'
base_path = '/'
port = 9001

[mqtt]
cmd = '/var/run/printnanny/cmd'
cipher = 'secp256r1'
keepalive = 300
ca_certs = ['/etc/ca-certificates']

[keys]
force_create = false
path = '/etc/printnanny/keys'
```