### PR TITLE
Implement printnanny-rtp-server.service

### DIFF
--- a/meta-printnanny/recipes-core/octoprint-apps/files/config.yaml
+++ b/meta-printnanny/recipes-core/octoprint-apps/files/config.yaml
@@ -19,12 +19,12 @@ system:
 
 events:
   subscriptions:
-    - command: sudo systemctl restart nnstreamer.service
+    - command: sudo systemctl start printnanny-cam.service
       debug: false
       event: plugin_octoprint_nanny_nnstreamer_start
       type: system
       enabled: true
-    - command: sudo systemctl stop nnstreamer.service
+    - command: sudo systemctl stop printnanny-cam.service
       enabled: true
       debug: false
       event: plugin_octoprint_nanny_nnstreamer_stop

--- a/meta-printnanny/recipes-core/octoprint-apps/files/octoprint-venv.service.tmpl
+++ b/meta-printnanny/recipes-core/octoprint-apps/files/octoprint-venv.service.tmpl
@@ -5,7 +5,7 @@ ConditionPathExists=!{OCTOPRINT_VENV}
 [Service]
 Type=oneshot
 SyslogIdentifier=octoprint-venv
-ExecStart=/usr/bin/python3 -m venv {OCTOPRINT_VENV} --system-site-packages
+ExecStart=/usr/bin/python3 -m venv --system-site-packages {OCTOPRINT_VENV}
 User={OCTOPRINT_USER}
 [Install]
 WantedBy=octoprint.service

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-cam.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-cam.service
@@ -8,11 +8,19 @@ PartOf=printnanny-online.target
 Type=simple
 SyslogIdentifier=printnanny-dash
 ExecStart=/usr/bin/printnanny-gst \
-    --encoder h264-hardware \
-    --host localhost \
-    --port-video 5105 \
-    --port-overlay 5106 \
+    --encoder=h264-hardware \
+    --host=localhost \
+    --port-data=5107 \
+    --port-overlay=5106 \
+    --port-video=5105 \
+    --sink udpsink \
+    --src libcamerasrc \
+    --tensor-height=320 \
+    --tensor-width=320 \
+    --tflite-labels=/usr/share/printnanny/model/dict.txt \
+    --tflite-model=/usr/share/printnanny/model/model.tflite \
     rtp-tflite-overlay
+
 Restart=on-failure
 RestartSec=30
 User=printnanny

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-cam.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-cam.service
@@ -7,19 +7,33 @@ PartOf=printnanny-online.target
 [Service]
 Type=simple
 SyslogIdentifier=printnanny-cam
-ExecStart=/usr/bin/printnanny-gst -v \
-    --encoder=h264-hardware \
-    --host=localhost \
-    --port-data=5107 \
-    --port-overlay=5106 \
-    --port-video=5105 \
-    --sink udpsink \
-    --src libcamerasrc \
-    --tensor-height=320 \
-    --tensor-width=320 \
-    --tflite-labels=/usr/share/printnanny/model/dict.txt \
-    --tflite-model=/usr/share/printnanny/model/model.tflite \
-    rtp-tflite-overlay
+
+ caps = application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264, packetization-mode=(string)1, sprop-parameter-sets=(string)"J0LAKJWgKA9oQAAAAwBAAAAMOSgACYlgABfXm97gHiRNQA\=\=\,KM4fIA\=\=", profile-level-id=(string)42c028, profile=(string)constrained-baseline, payload=(int)96, ssrc=(uint)2012639465, timestamp-offset=(uint)3384043561, seqnum-offset=(uint)30982, a-framerate=(string)24
+
+ExecStart=gst-launch-1.0 -v \
+    udpsrc port=5205 caps="application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264, payload=(int)96, packetization-mode=(string)1, profile-level-id=(string)42c028, profile=(string)constrained-baseline, a-framerate=(string)24" \
+    ! queue2 \
+    ! rtph264depay \
+    ! h264parse \
+    ! v4l2h264dec extra-controls="controls,repeat_sequence_header=1" \
+    ! v4l2convert \
+    ! video/x-raw,format=RGB,width=640,height=480 \
+    ! videoscale ! video/x-raw,width=320,height=320 \
+    ! tensor_converter \
+    ! tensor_transform mode=arithmetic option=typecast:uint8,add:0,div:1 \
+    ! other/tensors,num_tensors=1,format=static \
+    ! queue2 \
+    ! tensor_filter \
+        framework=tensorflow2-lite \
+        model=/usr/share/printnanny/model/model.tflite \
+    ! tensor_decoder mode=bounding_boxes option1=mobilenet-ssd-postprocess option2=/usr/share/printnanny/model/dict.txt option3=0:1:2:3,50 option4=640:480 option5=320:320 \
+    ! queue2 \
+    ! v4l2convert \
+    ! v4l2h264enc extra-controls="controls,repeat_sequence_header=1" \
+    ! 'video/x-h264,width=640,height=480,level=(string)4' \
+    ! h264parse \
+    ! rtph264pay \
+    ! udpsink host=127.0.0.1 port=5106
 
 Restart=on-failure
 RestartSec=30

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-cam.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-cam.service
@@ -6,8 +6,8 @@ PartOf=printnanny-online.target
 
 [Service]
 Type=simple
-SyslogIdentifier=printnanny-dash
-ExecStart=/usr/bin/printnanny-gst \
+SyslogIdentifier=printnanny-cam
+ExecStart=/usr/bin/printnanny-gst -v \
     --encoder=h264-hardware \
     --host=localhost \
     --port-data=5107 \

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-cam.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-cam.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=PrintNanny Cam Service
+After=network-online.target printnanny-sync.service
+Wants=network-online.target printnanny-sync.service 
+PartOf=printnanny-online.target
+
+[Service]
+Type=simple
+SyslogIdentifier=printnanny-dash
+ExecStart=/usr/bin/printnanny-gst \
+    --encoder h264-hardware \
+    --host localhost \
+    --port-video 5105 \
+    --port-overlay 5106 \
+    rtp-tflite-overlay
+Restart=on-failure
+RestartSec=30
+User=printnanny
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-dash.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-dash.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=PrintNanny Dashboard
-After=network-online.target printnanny-sync.service  etc-printnanny.mount
+After=network-online.target printnanny-sync.service etc-printnanny.mount
 Wants=network-online.target printnanny-sync.service 
 Requires=etc-printnanny.mount
 PartOf=printnanny-online.target

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-link-confd.sh
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-link-confd.sh
@@ -40,7 +40,7 @@ else
 fi
 
 # quick fix for Raspberry Pi userland expecting video group w/ 0660
-FIX_VIDEO_GROUP=(
+FIX_VIDEO_GROUP_FILES=(
     "/dev/rpivid-h264mem"
     "/dev/rpivid-hevcmem"
     "/dev/rpivid-intcmem"
@@ -49,13 +49,26 @@ FIX_VIDEO_GROUP=(
     "/dev/vchiq"
     "/dev/vcio"
     "/dev/vcsm-cma"
+    "/dev/dma_heap/linux,cma"
+    "/dev/dma_heap/system"
 )
 
-for f in "${FIX_VIDEO_GROUP[@]}"
+FIX_VIDEO_GROUP_DIRS=(
+    "/dev/dma_heap/"
+)
+
+for f in "${FIX_VIDEO_GROUP_FILES[@]}"
 do
     echo "Changing group ownership of $f to root:video"
     chown :video "$f"
     chmod 660 "$f"
+done
+
+for f in "${FIX_VIDEO_GROUP_DIRS[@]}"
+do
+    echo "Changing group ownership of $f to root:video"
+    chown :video "$f"
+    chmod 755 "$f"
 done
 
 FIX_PRINTNANNY_GROUP=(

--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-rtp-server.service
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-rtp-server.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=PrintNanny RTP Server
+After=network-online.target printnanny-sync.service
+Wants=network-online.target printnanny-sync.service 
+PartOf=printnanny-online.target
+
+[Service]
+Type=simple
+SyslogIdentifier=printnanny-rtp-server
+ExecStart=gst-launch-1.0 -v \
+    rtpbin name=rtpbin1 \
+    libcamerasrc \
+    ! capsfilter caps="video/x-raw,width=640,height=480,framerate=24/1" \
+    ! v4l2convert \
+    ! v4l2h264enc extra-controls="controls,repeat_sequence_header=1" \
+    ! 'video/x-h264,width=640,height=480,level=(string)4' \
+    ! h264parse \
+    ! rtph264pay \
+    ! rtpbin1.send_rtp_sink_0 \
+    rtpbin1.send_rtp_src_0 ! tee name=t \
+    t. ! queue2 ! udpsink host=127.0.0.1 port=5105 \
+    t. ! queue2 ! udpsink host=127.0.0.1 port=5205 \
+    udpsrc port=5206 ! rtpbin1.recv_rtp_sink_0
+
+Restart=on-failure
+RestartSec=30
+User=printnanny
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
+++ b/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/AGPL-3.0-or-la
 SRC_URI = " \
     https://pki.goog/gtsltsr/gtsltsr.crt;name=gtsltsr \
     https://pki.goog/gsr4/GSR4.crt;name=GSR4 \
+    file://printnanny-cam.service \
     file://printnanny-dash.service \
     file://printnanny-sync.service \
     file://printnanny-mqtt.service \
@@ -33,6 +34,7 @@ do_install() {
   install -d "${D}${sysconfdir}/systemd/system/printnanny-mqtt.service.d"
   install -d "${D}${bindir}"
   install -m 0644 "${WORKDIR}/Rocket.toml" "${D}${sysconfdir}/printnanny/dash/Rocket.toml"
+  install -m 0644 "${WORKDIR}/printnanny-cam.service" "${D}${systemd_system_unitdir}/printnanny-cam.service"
   install -m 0644 "${WORKDIR}/printnanny-dash.service" "${D}${systemd_system_unitdir}/printnanny-dash.service"
   install -m 0644 "${WORKDIR}/printnanny-sync.service" "${D}${systemd_system_unitdir}/printnanny-sync.service"
   install -m 0644 "${WORKDIR}/printnanny-mqtt.service" "${D}${systemd_system_unitdir}/printnanny-mqtt.service"
@@ -46,6 +48,7 @@ do_install() {
 FILES:${PN} = "${datadir} ${sysconfdir} ${bindir}/* ${systemd_unitdir}/*"
 
 SYSTEMD_SERVICE:${PN} = "\
+  printnanny-cam.service \
   printnanny-dash.service \
   printnanny-sync.service \
   printnanny-mqtt.service \

--- a/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
+++ b/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
@@ -10,6 +10,7 @@ SRC_URI = " \
     file://printnanny-dash.service \
     file://printnanny-sync.service \
     file://printnanny-mqtt.service \
+    file://printnanny-rtp-server.service \
     file://printnanny-online.service \
     file://printnanny-online.target \
     file://printnanny-link-confd.sh \
@@ -35,6 +36,7 @@ do_install() {
   install -d "${D}${bindir}"
   install -m 0644 "${WORKDIR}/Rocket.toml" "${D}${sysconfdir}/printnanny/dash/Rocket.toml"
   install -m 0644 "${WORKDIR}/printnanny-cam.service" "${D}${systemd_system_unitdir}/printnanny-cam.service"
+  install -m 0644 "${WORKDIR}/printnanny-rtp-server.service" "${D}${systemd_system_unitdir}/printnanny-rtp-server.service"
   install -m 0644 "${WORKDIR}/printnanny-dash.service" "${D}${systemd_system_unitdir}/printnanny-dash.service"
   install -m 0644 "${WORKDIR}/printnanny-sync.service" "${D}${systemd_system_unitdir}/printnanny-sync.service"
   install -m 0644 "${WORKDIR}/printnanny-mqtt.service" "${D}${systemd_system_unitdir}/printnanny-mqtt.service"
@@ -48,6 +50,7 @@ do_install() {
 FILES:${PN} = "${datadir} ${sysconfdir} ${bindir}/* ${systemd_unitdir}/*"
 
 SYSTEMD_SERVICE:${PN} = "\
+  printnanny-rtp-server.service \
   printnanny-cam.service \
   printnanny-dash.service \
   printnanny-sync.service \

--- a/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get printnanny-gst could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/printnanny-gst/0.23.0"
 SRC_URI += "git://git@github.com/bitsy-ai/print-nanny-cli.git;protocol=ssh;nobranch=1;branch=main"
-SRCREV = "dcf9ee6402ea226be2581340c74dce3525afa80a"
+SRCREV = "035f1db28af0569039d43f2b5218294b7536895c"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "gst"
-PV:append = ".AUTOINC+dcf9ee6402"
+PV:append = ".AUTOINC+035f1db28a"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched

--- a/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get printnanny-gst could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/printnanny-gst/0.23.0"
 SRC_URI += "git://git@github.com/bitsy-ai/print-nanny-cli.git;protocol=ssh;nobranch=1;branch=main"
-SRCREV = "035f1db28af0569039d43f2b5218294b7536895c"
+SRCREV = "9d5a64ee02cbbd2cea473ef7f5af43a2604ee42f"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "gst"
-PV:append = ".AUTOINC+035f1db28a"
+PV:append = ".AUTOINC+9d5a64ee02"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched

--- a/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get printnanny-gst could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/printnanny-gst/0.23.0"
 SRC_URI += "git://git@github.com/bitsy-ai/print-nanny-cli.git;protocol=ssh;nobranch=1;branch=fix-tee-pads"
-SRCREV = "3873c7a48d44f78fe1b47121eeb3f2e1de51a2fa"
+SRCREV = "5c397414a2bacaa0d090c26e03b31dd0b685e7a7"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "gst"
-PV:append = ".AUTOINC+3873c7a48d"
+PV:append = ".AUTOINC+5c397414a2"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched

--- a/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
@@ -7,11 +7,11 @@ inherit cargo
 
 # how to get printnanny-gst could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/printnanny-gst/0.23.0"
-SRC_URI += "git://git@github.com/bitsy-ai/print-nanny-cli.git;protocol=ssh;nobranch=1;branch=main"
-SRCREV = "9d5a64ee02cbbd2cea473ef7f5af43a2604ee42f"
+SRC_URI += "git://git@github.com/bitsy-ai/print-nanny-cli.git;protocol=ssh;nobranch=1;branch=fix-tee-pads"
+SRCREV = "297ce9e6b29ebec27177c861d5ebd7305ed3d5e2"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "gst"
-PV:append = ".AUTOINC+9d5a64ee02"
+PV:append = ".AUTOINC+297ce9e6b2"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched

--- a/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-rs/printnanny-gst_0.23.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get printnanny-gst could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/printnanny-gst/0.23.0"
 SRC_URI += "git://git@github.com/bitsy-ai/print-nanny-cli.git;protocol=ssh;nobranch=1;branch=fix-tee-pads"
-SRCREV = "297ce9e6b29ebec27177c861d5ebd7305ed3d5e2"
+SRCREV = "3873c7a48d44f78fe1b47121eeb3f2e1de51a2fa"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = "gst"
-PV:append = ".AUTOINC+297ce9e6b2"
+PV:append = ".AUTOINC+3873c7a48d"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched

--- a/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,7 +1,7 @@
 # https://github.com/bitsy-ai/printnanny-os/issues/15#issuecomment-1162805510
 # update cma=64M kernel parameter, which is set by RASPBERRYPI_CAMERA_V2 / RASPBERRYPI_HD_CAMERA
 CMDLINE:remove = "cma=64M"
-CMDLINE:remove = "cma=128M"
+CMDLINE:append = "cma=128M"
 
 # Note also that Linux supports multiple consoles for output - but only one for input
 # the last named (or default if none named) from the kernel commandline specifies which is used for input, and all are used for output

--- a/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,7 +1,7 @@
 # https://github.com/bitsy-ai/printnanny-os/issues/15#issuecomment-1162805510
-# remove cma=64M kernel parameter, which is set by RASPBERRYPI_CAMERA_V2 / RASPBERRYPI_HD_CAMERA
-
+# update cma=64M kernel parameter, which is set by RASPBERRYPI_CAMERA_V2 / RASPBERRYPI_HD_CAMERA
 CMDLINE:remove = "cma=64M"
+CMDLINE:remove = "cma=128M"
 
 # Note also that Linux supports multiple consoles for output - but only one for input
 # the last named (or default if none named) from the kernel commandline specifies which is used for input, and all are used for output

--- a/recipes-bsp/bootfiles/rpi-config_%.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_%.bbappend
@@ -1,3 +1,8 @@
+GPU_MEM = "128"
+GPU_MEM_256 = "64"
+GPU_MEM_512 = "128"
+GPU_MEM_1024 = "256"
+
 do_deploy:append(){
     echo "bootcode_delay=2" >> $CONFIG
     echo "max_framebuffers=2" >> $CONFIG

--- a/recipes-multimedia/janus-gateway/files/janus.plugin.streaming.jcfg
+++ b/recipes-multimedia/janus-gateway/files/janus.plugin.streaming.jcfg
@@ -263,25 +263,33 @@ general: {
     #rtsp_conn_timeout = 5
 #}
 
-h264-nn: {
+rtp-live-cam: {
     type = "rtp"
     id = 200
-    description = "PrintNanny Vision (h264 encoded)"
+    description = "PrintNanny Cam (24 FPS)"
     media = (
         {
             type = "video"
             mid = "v1"
-            label = "h264-encoded video"
+            label = "H264-encoded camera stream"
             port = 5105
-            pt = 100
+            pt = 96
             rtpmap = "H264/90000"
-        },
+        }
+    )
+}
+
+rtp-vision-simulation: {
+    type = "rtp"
+    id = 201
+    description = "PrintNanny Vision Simulation (1 FPS)"
+    media = (
         {
             type = "video"
-            mid = "v2"
-            label = "PrintNanny Vision"
+            mid = "v1"
+            label = "H264-encoded composite of rtp-cam and bounding box streams (downsampled)"
             port = 5106
-            pt = 100
+            pt = 26
             rtpmap = "H264/90000"
         }
     )

--- a/recipes-multimedia/janus-gateway/files/janus.plugin.streaming.jcfg
+++ b/recipes-multimedia/janus-gateway/files/janus.plugin.streaming.jcfg
@@ -289,7 +289,7 @@ rtp-vision-simulation: {
             mid = "v1"
             label = "H264-encoded composite of rtp-cam and bounding box streams (downsampled)"
             port = 5106
-            pt = 26
+            pt = 96
             rtpmap = "H264/90000"
         }
     )


### PR DESCRIPTION
After some experimentation, I suspect running tflite and video encoding in one pipeline is the cause of stutters/freezing due to synchronization issues (example pipeline below). One tee stream is intended to run in near-realtime, while the other tee stream is much slower and should drop frames via leaky buffer.

```
gst-launch-1.0 --verbose libcamerasrc \
    ! capsfilter caps="video/x-raw,format=RGB,width=640,height=480,framerate=0/1" \
    ! tee name=t \
    t.  ! queue leaky=2 max-size-buffers=2 \
        ! videoconvert \
        ! videoscale ! video/x-raw,width=320,height=320 \
        ! tensor_converter \
        ! tensor_transform mode=arithmetic option=typecast:uint8,add:0,div:1 \
        ! other/tensors,num_tensors=1,format=static \
        ! tensor_filter \
            framework=tensorflow2-lite \
            model=/usr/share/printnanny/model/model.tflite \
        ! tensor_decoder mode=bounding_boxes option1=mobilenet-ssd-postprocess option2=/usr/share/printnanny/model/dict.txt option3=0:1:2:3,66 option4=640:480 option5=320:320 \
        ! videoconvert name=v4l2convert0 \
        ! v4l2h264enc extra-controls="controls,repeat_sequence_header=1" name=v4l2h264enc0 \
        ! 'video/x-h264,width=640,height=480,level=(string)4' \
        ! h264parse \
        ! rtph264pay \
        ! udpsink host="$GSTREAMER_UDP_SINK_HOST" port="$GSTREAMER_UDP_SINK_PORT_OVERLAY" \
    t.  ! queue leaky=2 max-size-buffers=2 \
        ! videoconvert name=v4l2convert1 \
        ! v4l2h264enc extra-controls="controls,repeat_sequence_header=1" name=v4l2h264enc1 \
        ! 'video/x-h264,width=640,height=480,level=(string)4' \
        ! h264parse \
        ! rtph264pay \
        ! udpsink host="$GSTREAMER_UDP_SINK_HOST" port="$GSTREAMER_UDP_SINK_PORT_VIDEO"

```

Instead of trying to get :point_up: pipeline running smoothly, I'm going to break the pipeline into a few components:

### printnanny-rtp-server
* Bind only to loopback
* Relay h264 video stream via rtp :5105 to janus streaming plugin
* Accept `udpsrc` on :5205, which allows downstream apps to sample/process the h264 video stream
* Accept `udpsink` on :5206 (unused), allows for arbitrary data relay if needed

### printnanny-cam
To be refactored in next PR