### PR TITLE
Fix formatting of runcmd

### DIFF
--- a/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-online.target
+++ b/meta-printnanny/recipes-core/printnanny-apps/files/printnanny-online.target
@@ -3,6 +3,3 @@ Description=PrintNanny Services Online
 Wants=printnanny-online.service
 After=printnanny-online.service
 Conflicts=rescue.service rescue.target
-
-[Install]
-WantedBy=multi-user.target

--- a/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
+++ b/meta-printnanny/recipes-core/printnanny-apps/printnanny-apps.bb
@@ -53,6 +53,7 @@ SYSTEMD_SERVICE:${PN} = "\
   printnanny-nats.service \
   printnanny-online.service \
   printnanny-online.target \
+  printnanny-online.target \
   printnanny-boot-report.service \
 "
 SYSTEMD_AUTO_ENABLE = "enable"

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init/003-runcmd.cfg
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init/003-runcmd.cfg
@@ -1,2 +1,2 @@
 runcmd:
-    - [ systemctl restart avahi-daemon.service]
+    - [ systemctl, restart, avahi-daemon.service ]


### PR DESCRIPTION
This snippet is being rendered as one string:

```
root@raspberrypi4-64:~# cat /var/lib/cloud/instance/scripts/runcmd
#!/bin/sh
'systemctl restart avahi-daemon.service'
```

This results in the `cloud-final.service` failing with error:
```
May 24 21:34:55 raspberrypi4-64 cloud-init[703]: Cloud-init v. 22.2 running 'modules:final' at Tue, 24 May 2022 21:34:55 +0000. Up 143.26 seconds.
May 24 21:34:55 raspberrypi4-64 cloud-init[703]: /var/lib/cloud/instance/scripts/runcmd: line 2: systemctl restart avahi-daemon.service: command not found
````