### PR TITLE
Fix transaction race for sshd.service

### DIFF
--- a/recipes-extended/cloud-init/cloud-init_22.2.bb
+++ b/recipes-extended/cloud-init/cloud-init_22.2.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c6dd79b6ec2130a3364f6fa9d6380408"
 
-SRCREV = "46aa12ec7f76f1e6173d0816fb09f44fbcbefbfb"
+SRCREV = "0590a389af83ec98cb386a9e5aad7767f9e1202f"
 SRC_BRANCH = "bitsy-distro"
 SRC_URI = "git://github.com/bitsy-ai/cloud-init;branch=${SRC_BRANCH};protocol=https \
     file://cloud-init-source-local-lsb-functions.patch \


### PR DESCRIPTION
I suspect the dependency on `sshd.socket` here is causing the following conflict:


```
root@pn-0-3-0:~# systemctl start sshd.service
Failed to start sshd.service: Transaction contains conflicting jobs 'stop' and 'start' for sshd.service. Probably contradicting requirement dependencies configured.
See system logs and 'systemctl status sshd.service' for details.
```