### PR TITLE
Bump mainsail to support-base-path-rc2

### DIFF
--- a/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
+++ b/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     https://github.com/bitsy-ai/mainsail/releases/download/${PV}/mainsail.zip;subdir=mainsail \
     file://mainsail.target \
 "
-SRC_URI[sha256sum] = "71917bea83d36beb831803d5da67b623a6ae3b3efa770d0134ca3eadf75aa001"
+SRC_URI[sha256sum] = "ae4e8b59b00c7ecc662e2b61d80aa1954fd3df26f49ac2236eda6affc2dbfb8d"
 S = "${WORKDIR}/mainsail"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 

--- a/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
+++ b/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     https://github.com/bitsy-ai/mainsail/releases/download/${PV}/mainsail.zip;subdir=mainsail \
     file://mainsail.target \
 "
-SRC_URI[sha256sum] = "8c1c1004b0ba148cffc0e233835d00b918ed460a347eb6430c28ddd0d0f6789c"
+SRC_URI[sha256sum] = "71917bea83d36beb831803d5da67b623a6ae3b3efa770d0134ca3eadf75aa001"
 S = "${WORKDIR}/mainsail"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 

--- a/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
+++ b/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
@@ -3,13 +3,12 @@ HOMEPAGE = "https://www.klipper3d.org/"
 LICENSE = "GPL-3.0-or-later"
 
 
-PV = "support-base-path-rc1"
-R = "rc1"
+PV = "support-base-path-rc2"
 SRC_URI = "\
     https://github.com/bitsy-ai/mainsail/releases/download/${PV}/mainsail.zip;subdir=mainsail \
     file://mainsail.target \
 "
-SRC_URI[sha256sum] = "ae4e8b59b00c7ecc662e2b61d80aa1954fd3df26f49ac2236eda6affc2dbfb8d"
+SRC_URI[sha256sum] = "70532f2332cee176a5c96a6a0e671121230ff35dff6cac8048982a558945bffe"
 S = "${WORKDIR}/mainsail"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 

--- a/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
+++ b/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     https://github.com/bitsy-ai/mainsail/releases/download/${PV}/mainsail.zip;subdir=mainsail \
     file://mainsail.target \
 "
-SRC_URI[sha256sum] = "e3d7fed6f7cc5eb04827f1d282508fb606be284cf92078524b06ae4c87e6e8a4"
+SRC_URI[sha256sum] = "e4378a91701bd163d3ff7a9e574444515c8fbf52c03134cd6ae3e32f03811344"
 S = "${WORKDIR}/mainsail"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 

--- a/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
+++ b/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     https://github.com/bitsy-ai/mainsail/releases/download/${PV}/mainsail.zip;subdir=mainsail \
     file://mainsail.target \
 "
-SRC_URI[sha256sum] = "e4378a91701bd163d3ff7a9e574444515c8fbf52c03134cd6ae3e32f03811344"
+SRC_URI[sha256sum] = "8c1c1004b0ba148cffc0e233835d00b918ed460a347eb6430c28ddd0d0f6789c"
 S = "${WORKDIR}/mainsail"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 

--- a/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
+++ b/meta-printnanny/recipes-3dprinter/mainsail/mainsail.bb
@@ -3,13 +3,13 @@ HOMEPAGE = "https://www.klipper3d.org/"
 LICENSE = "GPL-3.0-or-later"
 
 
-PV = "support-base-path-rc0"
-R = "rc0"
+PV = "support-base-path-rc1"
+R = "rc1"
 SRC_URI = "\
     https://github.com/bitsy-ai/mainsail/releases/download/${PV}/mainsail.zip;subdir=mainsail \
     file://mainsail.target \
 "
-SRC_URI[sha256sum] = "28f5944c821bce74788570f0e6e4a85de158a457a10a7e8177a613d809a33f04"
+SRC_URI[sha256sum] = "e3d7fed6f7cc5eb04827f1d282508fb606be284cf92078524b06ae4c87e6e8a4"
 S = "${WORKDIR}/mainsail"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 

--- a/meta-printnanny/recipes-httpd/nginx/nginx/mainsail.locations.template
+++ b/meta-printnanny/recipes-httpd/nginx/nginx/mainsail.locations.template
@@ -27,8 +27,8 @@ location /mainsail/websocket {
     proxy_read_timeout 86400;
 }
 
-location ~^/mainsail/(printer|api|access|machine|server)/ {
-    proxy_pass http://moonraker$request_uri;
+location ~^/mainsail/(printer|api|access|machine|server)/(.*) {
+    proxy_pass http://moonraker/$1/$2;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/meta-printnanny/recipes-httpd/nginx/nginx/mainsail.locations.template
+++ b/meta-printnanny/recipes-httpd/nginx/nginx/mainsail.locations.template
@@ -27,8 +27,8 @@ location /mainsail/websocket {
     proxy_read_timeout 86400;
 }
 
-location ~^/mainsail/(printer|api|access|machine|server)/(.*) {
-    proxy_pass http://moonraker/$1/$2;
+location ~^/mainsail/(printer|api|access|machine|server)(.*) {
+    proxy_pass http://moonraker/$1$2;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
closes: https://github.com/bitsy-ai/printnanny-os/issues/146
