### PR TITLE
Ship gcc compiler with klipper package

### DIFF
--- a/meta-printnanny/recipes-3dprinter/klipper/klipper_git.bb
+++ b/meta-printnanny/recipes-3dprinter/klipper/klipper_git.bb
@@ -67,7 +67,9 @@ RDEPENDS:${PN} = "\
     zlib \
     expat \
     glibc \
+    gcc \
 "
+
 
 RDEPENDS:${PN}-scripts = "\
     bash \

--- a/meta-printnanny/recipes-3dprinter/klipper/klipper_git.bb
+++ b/meta-printnanny/recipes-3dprinter/klipper/klipper_git.bb
@@ -67,7 +67,7 @@ RDEPENDS:${PN} = "\
     zlib \
     expat \
     glibc \
-    gcc \
+    packagegroup-core-buildessential \
 "
 
 


### PR DESCRIPTION
Klipper has a runtime dependency on gcc. Klippy server is currently failing to start with error:

```
Nov 14 15:33:11 pn-v0-4 systemd[1]: Started Starts Klipper and provides klippy Unix Domain Socket API.
Nov 14 15:33:13 pn-v0-4 python3[836]: sh: line 1: gcc: command not found
```