### PR TITLE
build script + ~documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ an image. It uses Docker to manage these components, and so requires that the
 sudo apt-get update
 sudo apt-get -y install git cpio git python3-full binutils bzip2 chrpath \
                         build-essential diffstat file gawk lz4 zstd wget \
-                        locales vim tini
+                        locales vim tini sudo
 
 # ensure en_US.UTF-8 locale is generated
 
-grep -q '^en_US.UTF-8 UTF-8' || echo 'en_US.UTF-8 UTF-8' | sudo tee -a /etc/locale.gen
+grep -q '^en_US.UTF-8 UTF-8' /etc/locale.gen || echo 'en_US.UTF-8 UTF-8' | sudo tee -a /etc/locale.gen
+local-gen
 
 # Obtain the langdale branch of poky
 git clone -b langdale git://git.yoctoproject.org/poky poky
@@ -41,51 +42,51 @@ git clone             https://github.com/bitsy-ai/meta-bitsy.git
 # Populate bblayers.conf
 mkdir -p build/conf
 cat > build/conf/bblayers.conf <<EOF
-  POKY_BBLAYERS_CONF_VERSION = "2"
+POKY_BBLAYERS_CONF_VERSION = "2"
 
-  BBPATH = "\${TOPDIR}"
-  BBFILES ?= ""
+BBPATH = "\${TOPDIR}"
+BBFILES ?= ""
 
-  BBLAYERS ?= " \
-    /poky/meta \
-    /poky/meta-poky \
-    /poky/meta-yocto-bsp \
-    /poky/meta-raspberrypi \
-    /poky/meta-openembedded/meta-oe \
-    /poky/meta-openembedded/meta-python \
-    /poky/meta-openembedded/meta-multimedia \
-    /poky/meta-bitsy \
-    /poky/meta-neural-network \
-    /poky/meta-bitsy/meta-printnanny \
-    /poky/meta-openembedded/meta-networking \
-    /poky/meta-openembedded/meta-filesystems \
-    /poky/meta-openembedded/meta-initramfs \
-    /poky/meta-openembedded/meta-webserver \
-    /poky/meta-swupdate \
-    /poky/meta-microcontroller \
-  "
+BBLAYERS ?= "
+  /poky/meta
+  /poky/meta-poky
+  /poky/meta-yocto-bsp
+  /poky/meta-raspberrypi
+  /poky/meta-openembedded/meta-oe
+  /poky/meta-openembedded/meta-python
+  /poky/meta-openembedded/meta-multimedia
+  /poky/meta-bitsy
+  /poky/meta-neural-network
+  /poky/meta-bitsy/meta-printnanny
+  /poky/meta-openembedded/meta-networking
+  /poky/meta-openembedded/meta-filesystems
+  /poky/meta-openembedded/meta-initramfs
+  /poky/meta-openembedded/meta-webserver
+  /poky/meta-swupdate
+  /poky/meta-microcontroller
+"
 EOF
 
 # populate locale.conf
 cat > build/conf/local.conf <<EOF
-  BUILDCFG_VARS = "VARIANT_NAME VARIANT_ID BB_VERSION BUILD_SYS NATIVELSBSTRING TARGET_SYS MACHINE DISTRO DISTRO_VERSION TUNE_FEATURES TARGET_FPU"
-  DISTRO = "printnanny"
-  IMAGE_FSTYPES = "tar.gz ext4 ext4.gz ext4 wic wic.gz wic.bmap"
-  MACHINE ?= "raspberrypi4-64"
-  RUST_VERSION ?= "1.64"
-  PATCHRESOLVE = "noop"
+BUILDCFG_VARS = "VARIANT_NAME VARIANT_ID BB_VERSION BUILD_SYS NATIVELSBSTRING TARGET_SYS MACHINE DISTRO DISTRO_VERSION TUNE_FEATURES TARGET_FPU"
+DISTRO = "printnanny"
+IMAGE_FSTYPES = "tar.gz ext4 ext4.gz ext4 wic wic.gz wic.bmap"
+MACHINE ?= "raspberrypi4-64"
+RUST_VERSION ?= "1.64"
+PATCHRESOLVE = "noop"
 
-  BB_DISKMON_DIRS ??= "\
-      STOPTASKS,\${TMPDIR},1G,100K \
-      STOPTASKS,\${DL_DIR},1G,100K \
-      STOPTASKS,\${SSTATE_DIR},1G,100K \
-      STOPTASKS,/tmp,100M,100K \
-      HALT,\${TMPDIR},100M,1K \
-      HALT,\${DL_DIR},100M,1K \
-      HALT,\${SSTATE_DIR},100M,1K \
-      HALT,/tmp,10M,1K"
+BB_DISKMON_DIRS ??= "
+    STOPTASKS,\${TMPDIR},1G,100K
+    STOPTASKS,\${DL_DIR},1G,100K
+    STOPTASKS,\${SSTATE_DIR},1G,100K
+    STOPTASKS,/tmp,100M,100K
+    HALT,\${TMPDIR},100M,1K
+    HALT,\${DL_DIR},100M,1K
+    HALT,\${SSTATE_DIR},100M,1K
+    HALT,/tmp,10M,1K"
 
-  CONF_VERSION = "2"
+CONF_VERSION = "2"
 EOF
 
 # run the build

--- a/README.md
+++ b/README.md
@@ -92,7 +92,12 @@ EOF
 
 # run the build
 source oe-init-build-env ./build
-bitbake printnanny-release-image
+
+echo "Before continuing, you need to accept several licenses that are required to build this software."
+echo "To accept these licenses, run:"
+echo "   echo 'LICENSE_FLAGS_ACCEPTED += \"commercial_gstreamer1.0-libav commercial_gstreamer1.0-plugins-ugly commercial_ffmpeg commercial_mpeg2dec synaptics-killswitch\"' >> conf/local.conf"
+echo "Then run:"
+echo "   bitbake printnanny-release-image"
 ```
 
 ### Supported Yocto Project Releases

--- a/README.md
+++ b/README.md
@@ -13,16 +13,19 @@ an image. It uses Docker to manage these components, and so requires that the
 ### Manual Process
 
 ```sh
+# are we root?
+
+[ $(id -u) = 0 ] || SUDO="sudo"
 # Install prerequisities
 
-sudo apt-get update
-sudo apt-get -y install git cpio git python3-full binutils bzip2 chrpath \
+$SUDO apt-get update
+$SUDO apt-get -y install git cpio git python3-full binutils bzip2 chrpath \
                         build-essential diffstat file gawk lz4 zstd wget \
-                        locales vim tini sudo
+                        locales vim tini
 
 # ensure en_US.UTF-8 locale is generated
 
-grep -q '^en_US.UTF-8 UTF-8' /etc/locale.gen || echo 'en_US.UTF-8 UTF-8' | sudo tee -a /etc/locale.gen
+grep -q '^en_US.UTF-8 UTF-8' /etc/locale.gen || echo 'en_US.UTF-8 UTF-8' | $SUDO tee -a /etc/locale.gen
 local-gen
 
 # Obtain the langdale branch of poky

--- a/README.md
+++ b/README.md
@@ -12,21 +12,19 @@ an image. It uses Docker to manage these components, and so requires that the
 
 ### Manual Process
 
+You can run the following steps, which [_must not_ be run as the `root` user](https://wiki.yoctoproject.org/wiki/Technical_FAQ#Why_can.27t_I_run_bitbake_as_root.3F) (however, you'll need `sudo` access).
+
 ```sh
-# are we root?
-
-[ $(id -u) = 0 ] || SUDO="sudo"
 # Install prerequisities
-
-$SUDO apt-get update
-$SUDO apt-get -y install git cpio git python3-full binutils bzip2 chrpath \
+sudo apt-get update
+sudo env DEBIAN_FRONTEND=noninteractive \
+      apt-get -y install git cpio git python3-full binutils bzip2 chrpath \
                         build-essential diffstat file gawk lz4 zstd wget \
-                        locales vim tini
+                        locales
 
 # ensure en_US.UTF-8 locale is generated
-
-grep -q '^en_US.UTF-8 UTF-8' /etc/locale.gen || echo 'en_US.UTF-8 UTF-8' | $SUDO tee -a /etc/locale.gen
-local-gen
+grep -q '^en_US.UTF-8 UTF-8' /etc/locale.gen || echo 'en_US.UTF-8 UTF-8' | sudo tee -a /etc/locale.gen
+sudo locale-gen
 
 # Obtain the langdale branch of poky
 git clone -b langdale git://git.yoctoproject.org/poky poky
@@ -50,23 +48,23 @@ POKY_BBLAYERS_CONF_VERSION = "2"
 BBPATH = "\${TOPDIR}"
 BBFILES ?= ""
 
-BBLAYERS ?= "
-  /poky/meta
-  /poky/meta-poky
-  /poky/meta-yocto-bsp
-  /poky/meta-raspberrypi
-  /poky/meta-openembedded/meta-oe
-  /poky/meta-openembedded/meta-python
-  /poky/meta-openembedded/meta-multimedia
-  /poky/meta-bitsy
-  /poky/meta-neural-network
-  /poky/meta-bitsy/meta-printnanny
-  /poky/meta-openembedded/meta-networking
-  /poky/meta-openembedded/meta-filesystems
-  /poky/meta-openembedded/meta-initramfs
-  /poky/meta-openembedded/meta-webserver
-  /poky/meta-swupdate
-  /poky/meta-microcontroller
+BBLAYERS ?= " \\
+  $PWD/meta \\
+  $PWD/meta-poky \\
+  $PWD/meta-yocto-bsp \\
+  $PWD/meta-raspberrypi \\
+  $PWD/meta-openembedded/meta-oe \\
+  $PWD/meta-openembedded/meta-python \\
+  $PWD/meta-openembedded/meta-multimedia \\
+  $PWD/meta-bitsy \\
+  $PWD/meta-neural-network \\
+  $PWD/meta-bitsy/meta-printnanny \\
+  $PWD/meta-openembedded/meta-networking \\
+  $PWD/meta-openembedded/meta-filesystems \\
+  $PWD/meta-openembedded/meta-initramfs \\
+  $PWD/meta-openembedded/meta-webserver \\
+  $PWD/meta-swupdate \\
+  $PWD/meta-microcontroller \\
 "
 EOF
 
@@ -79,14 +77,14 @@ MACHINE ?= "raspberrypi4-64"
 RUST_VERSION ?= "1.64"
 PATCHRESOLVE = "noop"
 
-BB_DISKMON_DIRS ??= "
-    STOPTASKS,\${TMPDIR},1G,100K
-    STOPTASKS,\${DL_DIR},1G,100K
-    STOPTASKS,\${SSTATE_DIR},1G,100K
-    STOPTASKS,/tmp,100M,100K
-    HALT,\${TMPDIR},100M,1K
-    HALT,\${DL_DIR},100M,1K
-    HALT,\${SSTATE_DIR},100M,1K
+BB_DISKMON_DIRS ??= " \\
+    STOPTASKS,\${TMPDIR},1G,100K \\
+    STOPTASKS,\${DL_DIR},1G,100K \\
+    STOPTASKS,\${SSTATE_DIR},1G,100K \\
+    STOPTASKS,/tmp,100M,100K \\
+    HALT,\${TMPDIR},100M,1K \\
+    HALT,\${DL_DIR},100M,1K \\
+    HALT,\${SSTATE_DIR},100M,1K \\
     HALT,/tmp,10M,1K"
 
 CONF_VERSION = "2"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,95 @@ The **meta-bitsy project** provides *recipes* for building [Embedded Linux](http
 
 Bitsy distros are designed for computer vision and machine learning applications.
 
+## Building
+
+`build.sh` is provided as a wrapper around the various components used to build
+an image. It uses Docker to manage these components, and so requires that the
+`docker` command be installed on your system.
+
+### Manual Process
+
+```sh
+# Install prerequisities
+
+sudo apt-get update
+sudo apt-get -y install git cpio git python3-full binutils bzip2 chrpath \
+                        build-essential diffstat file gawk lz4 zstd wget \
+                        locales vim tini
+
+# ensure en_US.UTF-8 locale is generated
+
+grep -q '^en_US.UTF-8 UTF-8' || echo 'en_US.UTF-8 UTF-8' | sudo tee -a /etc/locale.gen
+
+# Obtain the langdale branch of poky
+git clone -b langdale git://git.yoctoproject.org/poky poky
+cd poky
+
+# Obtain other dependencies
+git clone             https://github.com/agherzan/meta-raspberrypi.git
+git clone -b langdale https://github.com/openembedded/meta-openembedded.git
+git clone             https://github.com/nnstreamer/meta-neural-network.git
+git clone             https://github.com/sbabic/meta-swupdate.git
+git clone             https://github.com/schnitzeltony/meta-microcontroller.git
+
+# Obtain meta-bitsy
+git clone             https://github.com/bitsy-ai/meta-bitsy.git
+
+# Populate bblayers.conf
+mkdir -p build/conf
+cat > build/conf/bblayers.conf <<EOF
+  POKY_BBLAYERS_CONF_VERSION = "2"
+
+  BBPATH = "\${TOPDIR}"
+  BBFILES ?= ""
+
+  BBLAYERS ?= " \
+    /poky/meta \
+    /poky/meta-poky \
+    /poky/meta-yocto-bsp \
+    /poky/meta-raspberrypi \
+    /poky/meta-openembedded/meta-oe \
+    /poky/meta-openembedded/meta-python \
+    /poky/meta-openembedded/meta-multimedia \
+    /poky/meta-bitsy \
+    /poky/meta-neural-network \
+    /poky/meta-bitsy/meta-printnanny \
+    /poky/meta-openembedded/meta-networking \
+    /poky/meta-openembedded/meta-filesystems \
+    /poky/meta-openembedded/meta-initramfs \
+    /poky/meta-openembedded/meta-webserver \
+    /poky/meta-swupdate \
+    /poky/meta-microcontroller \
+  "
+EOF
+
+# populate locale.conf
+cat > build/conf/local.conf <<EOF
+  BUILDCFG_VARS = "VARIANT_NAME VARIANT_ID BB_VERSION BUILD_SYS NATIVELSBSTRING TARGET_SYS MACHINE DISTRO DISTRO_VERSION TUNE_FEATURES TARGET_FPU"
+  DISTRO = "printnanny"
+  IMAGE_FSTYPES = "tar.gz ext4 ext4.gz ext4 wic wic.gz wic.bmap"
+  MACHINE ?= "raspberrypi4-64"
+  RUST_VERSION ?= "1.64"
+  PATCHRESOLVE = "noop"
+
+  BB_DISKMON_DIRS ??= "\
+      STOPTASKS,\${TMPDIR},1G,100K \
+      STOPTASKS,\${DL_DIR},1G,100K \
+      STOPTASKS,\${SSTATE_DIR},1G,100K \
+      STOPTASKS,/tmp,100M,100K \
+      HALT,\${TMPDIR},100M,1K \
+      HALT,\${DL_DIR},100M,1K \
+      HALT,\${SSTATE_DIR},100M,1K \
+      HALT,/tmp,10M,1K"
+
+  CONF_VERSION = "2"
+EOF
+
+# run the build
+source oe-init-build-env ./build
+bitbake printnanny-release-image
+```
+
 ### Supported Yocto Project Releases
 
 <table>

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -e
+
+#/ build.sh [--qemu]
+#/
+#/ Leverages docker to produce a Print Nanny image, optionally targeting qemu
+#/ (untested) instead of the Raspberry Pi 4.
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "⛔ docker is required for build.sh, but it could not be found. please install docker and try again." >&2
+  exit 1
+fi
+
+usage() {
+  grep '^#/' "$0" | cut -c 4- >&2
+  exit 1
+}
+
+MACHINE="raspberrypi4-64"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --qemu) MACHINE=qemux86-64; shift ;;
+    *) usage ;;
+  esac
+done
+
+DOCKER_BUILDKIT=true docker build -t printnanny-yocto -f docker/Dockerfile .
+
+docker run \
+  --mount type=volume,source=printnanny-yocto-cache,destination=/poky/build/cache \
+  --mount type=volume,source=printnanny-yocto-sscache,destination=/poky/build/sstate-cache \
+  -e MACHINE="$MACHINE" \
+  -it \
+  printnanny-yocto \
+    printnanny-release-image

--- a/build.sh
+++ b/build.sh
@@ -35,18 +35,14 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-DOCKER_BUILDKIT=true docker build -t printnanny-yocto -f docker/Dockerfile .
+DOCKER_BUILDKIT=true docker build --pull -t printnanny-yocto -f docker/Dockerfile .
 
 mkdir -p output
 
 docker run \
-  --mount type=volume,source=printnanny-yocto-cache,destination=/poky/build/cache \
-  --mount type=volume,source=printnanny-yocto-downloads,destination=/poky/build/downloads \
-  --mount type=volume,source=printnanny-yocto-sscache,destination=/poky/build/sstate-cache \
-  --mount type=volume,source=printnanny-yocto-tmp,destination=/poky/build/tmp \
   --mount type=bind,source="$(pwd)/output",target=/output \
   ubuntu:22.04 \
-  chown -R 999 /poky/build /output
+  chown -R 999 /output
 
 docker run \
   --mount type=volume,source=printnanny-yocto-cache,destination=/poky/build/cache \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:22.04
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get -y install git
+
+RUN useradd -d /work --no-create-home --system yocto; \
+    mkdir /poky; \
+    chown yocto /poky
+WORKDIR /poky
+
+USER yocto
+RUN git clone -b langdale git://git.yoctoproject.org/poky /poky
+
+USER root
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install cpio git python3-full binutils bzip2 chrpath \
+                       build-essential diffstat file gawk lz4 zstd wget \
+                       locales vim tini
+
+RUN echo en_US.UTF-8 UTF-8 > /etc/locale.gen; locale-gen
+
+USER yocto
+RUN git clone             https://github.com/agherzan/meta-raspberrypi.git          /poky/meta-raspberrypi
+RUN git clone -b langdale https://github.com/openembedded/meta-openembedded         /poky/meta-openembedded
+RUN git clone             https://github.com/nnstreamer/meta-neural-network.git     /poky/meta-neural-network
+RUN git clone             https://github.com/sbabic/meta-swupdate.git               /poky/meta-swupdate
+RUN git clone             https://github.com/schnitzeltony/meta-microcontroller.git /poky/meta-microcontroller
+
+COPY .git                 /poky/meta-bitsy/.git
+COPY classes              /poky/meta-bitsy/classes
+COPY conf                 /poky/meta-bitsy/conf
+COPY meta-printnanny      /poky/meta-bitsy/meta-printnanny
+COPY recipes-connectivity /poky/meta-bitsy/recipes-connectivity
+COPY recipes-core         /poky/meta-bitsy/recipes-core
+COPY recipes-extended     /poky/meta-bitsy/recipes-extended
+COPY recipes-multimedia   /poky/meta-bitsy/recipes-extended
+
+COPY docker/bblayers.conf docker/local.conf /poky/build/conf/
+
+USER root
+RUN chown -R yocto /poky/meta-bitsy /poky/build
+
+COPY docker/entrypoint.sh /
+
+USER yocto
+RUN /entrypoint.sh -p
+ENTRYPOINT [ "tini", "--", "/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ COPY conf                 /poky/meta-bitsy/conf
 COPY meta-printnanny      /poky/meta-bitsy/meta-printnanny
 COPY recipes-connectivity /poky/meta-bitsy/recipes-connectivity
 COPY recipes-core         /poky/meta-bitsy/recipes-core
+COPY recipes-devtools     /poky/meta-bitsy/recipes-devtools
 COPY recipes-extended     /poky/meta-bitsy/recipes-extended
 COPY recipes-multimedia   /poky/meta-bitsy/recipes-multimedia
 COPY recipes-tensorflow   /poky/meta-bitsy/recipes-tensorflow

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,11 +29,13 @@ RUN --mount=type=cache,target=/var/cache/apt \
 RUN echo en_US.UTF-8 UTF-8 > /etc/locale.gen; locale-gen
 
 USER yocto
-RUN git clone             https://github.com/agherzan/meta-raspberrypi.git          /poky/meta-raspberrypi
-RUN git clone -b langdale https://github.com/openembedded/meta-openembedded         /poky/meta-openembedded
+RUN git clone -b langdale https://github.com/agherzan/meta-raspberrypi.git          /poky/meta-raspberrypi
+RUN git clone -b langdale https://github.com/openembedded/meta-openembedded.git     /poky/meta-openembedded; \
+    cd /poky/meta-openembedded; git reset --hard c5668905a6d8a78fb72c2cbf8b20e91e686ceb86
 RUN git clone             https://github.com/nnstreamer/meta-neural-network.git     /poky/meta-neural-network
 RUN git clone             https://github.com/sbabic/meta-swupdate.git               /poky/meta-swupdate
 RUN git clone             https://github.com/schnitzeltony/meta-microcontroller.git /poky/meta-microcontroller
+
 
 COPY classes              /poky/meta-bitsy/classes
 COPY conf                 /poky/meta-bitsy/conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,8 @@ COPY meta-printnanny      /poky/meta-bitsy/meta-printnanny
 COPY recipes-connectivity /poky/meta-bitsy/recipes-connectivity
 COPY recipes-core         /poky/meta-bitsy/recipes-core
 COPY recipes-extended     /poky/meta-bitsy/recipes-extended
-COPY recipes-multimedia   /poky/meta-bitsy/recipes-extended
+COPY recipes-multimedia   /poky/meta-bitsy/recipes-multimedia
+COPY recipes-tensorflow   /poky/meta-bitsy/recipes-tensorflow
 
 COPY docker/bblayers.conf docker/local.conf /poky/build/conf/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,6 @@ RUN git clone             https://github.com/nnstreamer/meta-neural-network.git 
 RUN git clone             https://github.com/sbabic/meta-swupdate.git               /poky/meta-swupdate
 RUN git clone             https://github.com/schnitzeltony/meta-microcontroller.git /poky/meta-microcontroller
 
-COPY .git                 /poky/meta-bitsy/.git
 COPY classes              /poky/meta-bitsy/classes
 COPY conf                 /poky/meta-bitsy/conf
 COPY meta-printnanny      /poky/meta-bitsy/meta-printnanny
@@ -49,9 +48,10 @@ COPY docker/bblayers.conf docker/local.conf /poky/build/conf/
 
 USER root
 RUN chown -R yocto /poky/meta-bitsy /poky/build
+COPY .git /poky/meta-bitsy/.git
+RUN chown -R yocto /poky/meta-bitsy/.git
 
 COPY docker/entrypoint.sh /
 
 USER yocto
-RUN /entrypoint.sh -p
 ENTRYPOINT [ "tini", "--", "/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,10 @@ COPY recipes-connectivity /poky/meta-bitsy/recipes-connectivity
 COPY recipes-core         /poky/meta-bitsy/recipes-core
 COPY recipes-devtools     /poky/meta-bitsy/recipes-devtools
 COPY recipes-extended     /poky/meta-bitsy/recipes-extended
+COPY recipes-graphics     /poky/meta-bitsy/recipes-graphics
+COPY recipes-kernel       /poky/meta-bitsy/recipes-kernel
 COPY recipes-multimedia   /poky/meta-bitsy/recipes-multimedia
+COPY recipes-support      /poky/meta-bitsy/recipes-support
 COPY recipes-tensorflow   /poky/meta-bitsy/recipes-tensorflow
 
 COPY docker/bblayers.conf docker/local.conf /poky/build/conf/

--- a/docker/bblayers.conf
+++ b/docker/bblayers.conf
@@ -1,0 +1,23 @@
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  /poky/meta \
+  /poky/meta-poky \
+  /poky/meta-yocto-bsp \
+  /poky/meta-raspberrypi \
+  /poky/meta-openembedded/meta-oe \
+  /poky/meta-openembedded/meta-python \
+  /poky/meta-openembedded/meta-multimedia \
+  /poky/meta-bitsy \
+  /poky/meta-neural-network \
+  /poky/meta-bitsy/meta-printnanny \
+  /poky/meta-openembedded/meta-networking \
+  /poky/meta-openembedded/meta-filesystems \
+  /poky/meta-openembedded/meta-initramfs \
+  /poky/meta-openembedded/meta-webserver \
+  /poky/meta-swupdate \
+  /poky/meta-microcontroller \
+"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+set -e
+
+cd /poky
+
+source oe-init-build-env /poky/build
+
+exec bitbake "$@"

--- a/docker/local.conf
+++ b/docker/local.conf
@@ -12,6 +12,8 @@ LICENSE_FLAGS_ACCEPTED += "\
 MACHINE ??= "qemux86-64"
 RUST_VERSION ?= "1.64"
 
+DEPLOY_DIR = "/output"
+
 #  "debug-tweaks"   - make an image suitable for development
 #                     e.g. ssh root access has a blank password
 # There are other application targets that can be used here too, see

--- a/docker/local.conf
+++ b/docker/local.conf
@@ -1,0 +1,51 @@
+BUILDCFG_VARS = "VARIANT_NAME VARIANT_ID BB_VERSION BUILD_SYS NATIVELSBSTRING TARGET_SYS MACHINE DISTRO DISTRO_VERSION TUNE_FEATURES TARGET_FPU"
+DISTRO = "printnanny"
+IMAGE_FSTYPES = "tar.gz ext4 ext4.gz ext4 wic wic.gz wic.bmap"
+LICENSE_FLAGS_ACCEPTED += "\
+    commercial_gstreamer1.0-libav \
+    commercial_gstreamer1.0-plugins-ugly \
+    commercial_ffmpeg \
+    commercial_mpeg2dec \
+    synaptics-killswitch \
+"
+# MACHINE ?= "raspberrypi4-64"
+MACHINE ??= "qemux86-64"
+RUST_VERSION ?= "1.64"
+
+#  "debug-tweaks"   - make an image suitable for development
+#                     e.g. ssh root access has a blank password
+# There are other application targets that can be used here too, see
+# meta/classes/image.bbclass and meta/classes/core-image.bbclass for more details.
+# We default to enabling the debugging tweaks.
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+
+# By default disable interactive patch resolution (tasks will just fail instead):
+PATCHRESOLVE = "noop"
+
+BB_DISKMON_DIRS ??= "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    HALT,${TMPDIR},100M,1K \
+    HALT,${DL_DIR},100M,1K \
+    HALT,${SSTATE_DIR},100M,1K \
+    HALT,/tmp,10M,1K"
+
+BB_SIGNATURE_HANDLER = "OEEquivHash"
+BB_HASHSERVE = "auto"
+BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
+SSTATE_MIRRORS ?= "file://.* https://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"
+
+# By default native qemu will build with a builtin VNC server where graphical output can be
+# seen. The line below enables the SDL UI frontend too.
+# PACKAGECONFIG:append:pn-qemu-system-native = " sdl"
+# By default libsdl2-native will be built, if you want to use your host's libSDL instead of 
+# the minimal libsdl built by libsdl2-native then uncomment the ASSUME_PROVIDED line below.
+#ASSUME_PROVIDED += "libsdl2-native"
+
+# You can also enable the Gtk UI frontend, which takes somewhat longer to build, but adds
+# a handy set of menus for controlling the emulator.
+#PACKAGECONFIG:append:pn-qemu-system-native = " gtk+"
+
+CONF_VERSION = "2"

--- a/meta-printnanny/recipes-core/images/files/qemuall/sw-description
+++ b/meta-printnanny/recipes-core/images/files/qemuall/sw-description
@@ -1,0 +1,5 @@
+software =
+{
+	version = "@@DISTRO_VERSION@@";
+	qemuall = {};
+}

--- a/meta-printnanny/recipes-core/printnanny-core-apps/printnanny-overlayfs.bb
+++ b/meta-printnanny/recipes-core/printnanny-core-apps/printnanny-overlayfs.bb
@@ -1,5 +1,7 @@
 inherit overlayfs
 
+LICENSE = "AGPL-3.0-or-later"
+
 OVERLAYFS_MOUNT_POINT[printnanny_etcd] = "/data"
 OVERLAYFS_WRITABLE_PATHS[printnanny_etcd] = "/etc/printnanny.d"
 OVERLAYFS_QA_SKIP[printnanny_etcd] = "mount-configured"

--- a/meta-printnanny/recipes-core/printnanny-dash/printnanny-dash_0.3.17.bb
+++ b/meta-printnanny/recipes-core/printnanny-dash/printnanny-dash_0.3.17.bb
@@ -7,6 +7,7 @@ SRC_URI = "\
 "
 SRC_URI[sha256sum] = "56b23386a243c711144a9aa7a631f497072722b568f2e70dd4522055761efe0b"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/AGPL-3.0-or-later;md5=a4af3f9f0c0fc9de318e4df46665906e"
+LICENSE = "AGPL-3.0-or-later"
 
 do_install(){
     install -d "${D}${bindir}"

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
@@ -4,9 +4,22 @@ HOMEPAGE = "https://github.com/bitsy-ai/printnanny-gst-plugin-rs"
 SRC_URI = "\
     https://github.com/bitsy-ai/printnanny-gst-plugin-rs/releases/download/printnanny-gst-plugin-v${PV}/printnanny-gst-plugin-v${PV}-${TARGET_ARCH}-unknown-linux-gnu.tar.gz \
 "
+
+SRC_URI[sha256sum] = "${@bb.utils.contains( \
+    'TARGET_ARCH', \
+    'aarch64', \
+    '78b8b9f15800aa5eeb75ad3e69c519b66cdd3e7ecbae910f69c2442b99fd3d9c', \
+    bb.utils.contains( \
+      'TARGET_ARCH', \
+      'x86_64', \
+      '3439fd013133a3c58440666a61338a03ffdaced819c7e53257e4730902b2c0bd', \
+      '', \
+      d), \
+    d)}"
+
 LICENSE = "AGPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/AGPL-3.0-or-later;md5=a4af3f9f0c0fc9de318e4df46665906e"
-SRC_URI[sha256sum] = "78b8b9f15800aa5eeb75ad3e69c519b66cdd3e7ecbae910f69c2442b99fd3d9c"
+
 do_install(){
     install -d "${D}${bindir}"
     install -d "${D}${libdir}/gstprintnanny"

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
@@ -1,21 +1,12 @@
 SUMMARY = "PrintNanny OS Gstreamer Plugin"
 HOMEPAGE = "https://github.com/bitsy-ai/printnanny-gst-plugin-rs"
 
-SRC_URI = "\
-    https://github.com/bitsy-ai/printnanny-gst-plugin-rs/releases/download/printnanny-gst-plugin-v${PV}/printnanny-gst-plugin-v${PV}-${TARGET_ARCH}-unknown-linux-gnu.tar.gz \
+SRC_URI:aarch64 = "\
+    https://github.com/bitsy-ai/printnanny-gst-plugin-rs/releases/download/printnanny-gst-plugin-v${PV}/printnanny-gst-plugin-v${PV}-${TARGET_ARCH}-unknown-linux-gnu.tar.gz;sha256sum=78b8b9f15800aa5eeb75ad3e69c519b66cdd3e7ecbae910f69c2442b99fd3d9c \
 "
-
-SRC_URI[sha256sum] = "${@bb.utils.contains( \
-    'TARGET_ARCH', \
-    'aarch64', \
-    '78b8b9f15800aa5eeb75ad3e69c519b66cdd3e7ecbae910f69c2442b99fd3d9c', \
-    bb.utils.contains( \
-      'TARGET_ARCH', \
-      'x86_64', \
-      '3439fd013133a3c58440666a61338a03ffdaced819c7e53257e4730902b2c0bd', \
-      '', \
-      d), \
-    d)}"
+SRC_URI:x86-64 = "\
+    https://github.com/bitsy-ai/printnanny-gst-plugin-rs/releases/download/printnanny-gst-plugin-v${PV}/printnanny-gst-plugin-v${PV}-${TARGET_ARCH}-unknown-linux-gnu.tar.gz;sha256sum=3439fd013133a3c58440666a61338a03ffdaced819c7e53257e4730902b2c0bd \
+"
 
 LICENSE = "AGPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/AGPL-3.0-or-later;md5=a4af3f9f0c0fc9de318e4df46665906e"

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
@@ -4,6 +4,7 @@ HOMEPAGE = "https://github.com/bitsy-ai/printnanny-gst-plugin-rs"
 SRC_URI = "\
     https://github.com/bitsy-ai/printnanny-gst-plugin-rs/releases/download/printnanny-gst-plugin-v${PV}/printnanny-gst-plugin-v${PV}-${TARGET_ARCH}-unknown-linux-gnu.tar.gz \
 "
+LICENSE = "AGPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/AGPL-3.0-or-later;md5=a4af3f9f0c0fc9de318e4df46665906e"
 SRC_URI[sha256sum] = "78b8b9f15800aa5eeb75ad3e69c519b66cdd3e7ecbae910f69c2442b99fd3d9c"
 do_install(){

--- a/meta-printnanny/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-printnanny/recipes-core/psplash/psplash_git.bbappend
@@ -7,6 +7,7 @@ SRC_URI += "\
     file://10-fb0-systemd.rules \
 "
 SPLASH_IMAGES:rpi = "file://psplash-printnanny-img.h;outsuffix=printnanny"
+SPLASH_IMAGES:qemux86-64 = "file://psplash-printnanny-img.h;outsuffix=printnanny"
 
 do_install:prepend() {
     install -d "${D}/etc/udev/rules.d"

--- a/meta-printnanny/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-printnanny/recipes-core/psplash/psplash_git.bbappend
@@ -6,8 +6,8 @@ SRC_URI += "\
     file://psplash-start.service \
     file://10-fb0-systemd.rules \
 "
-SPLASH_IMAGES:rpi = "file://psplash-printnanny-img.h;outsuffix=printnanny"
-SPLASH_IMAGES:qemux86-64 = "file://psplash-printnanny-img.h;outsuffix=printnanny"
+
+SPLASH_IMAGES:printnanny = "file://psplash-printnanny-img.h;outsuffix=printnanny"
 
 do_install:prepend() {
     install -d "${D}/etc/udev/rules.d"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-pyyaml_6.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-pyyaml_6.0.bb
@@ -13,4 +13,6 @@ S = "${WORKDIR}/PyYAML-6.0"
 
 RDEPENDS:${PN} = ""
 
+DEPENDS = "libyaml ${PYTHON_PN}-cython-native"
+
 inherit setuptools3

--- a/meta-printnanny/recipes-multimedia/packagegroups/packagegroup-printnanny-webrtc.bb
+++ b/meta-printnanny/recipes-multimedia/packagegroups/packagegroup-printnanny-webrtc.bb
@@ -7,6 +7,6 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
     gstreamer-apps \
-    libcamera-apps \
+    ${@bb.utils.contains('MACHINE', 'raspberrypi4', 'libcamera-apps', '', d)} \
     janus-gateway \
 "

--- a/recipes-multimedia/libcamera/libcamera_0.0.1.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.0.1.bb
@@ -34,8 +34,6 @@ EXTRA_OEMESON = " \
     -Ddocumentation=disabled \
 "
 
-MESON_BUILDTYPE:printnanny = "release"
-
 RDEPENDS:${PN} = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland qt', 'qtwayland', '', d)}"
 
 inherit meson pkgconfig python3native

--- a/recipes-multimedia/libcamera/libcamera_0.0.1.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.0.1.bb
@@ -34,6 +34,8 @@ EXTRA_OEMESON = " \
     -Ddocumentation=disabled \
 "
 
+MESON_BUILDTYPE:printnanny = "release"
+
 RDEPENDS:${PN} = "${@bb.utils.contains('DISTRO_FEATURES', 'wayland qt', 'qtwayland', '', d)}"
 
 inherit meson pkgconfig python3native


### PR DESCRIPTION
This adds:

1. a docker-based build script to produce builds from scratch; and
2. the list of specific commands that a human could run (e.g., by pasting into a terminal) to configure an Ubuntu environment to perform builds

I've tested both locally, the former by running `build.sh` directly & the latter by pasting the commands into a very slightly prepared (`apt-get update; apt-get -y install sudo; useradd -m -G sudo -p '' -s /bin/bash yocto; exec su - yocto`) `ubuntu:22.04` docker container. 