### PR TITLE
fix a handful of systemd config issues

### DIFF
--- a/meta-printnanny/recipes-3dprinter/mainsail/files/mainsail.target
+++ b/meta-printnanny/recipes-3dprinter/mainsail/files/mainsail.target
@@ -1,7 +1,5 @@
 [Unit]
 Description=systemd unit to group all Mainsail, Moonraker, Klipper services
-
-[Service]
 Wants=klipper.service moonraker.service
 
 [Install]

--- a/meta-printnanny/recipes-3dprinter/moonraker/files/moonraker.service
+++ b/meta-printnanny/recipes-3dprinter/moonraker/files/moonraker.service
@@ -21,6 +21,6 @@ Type=simple
 SupplementaryGroups=moonraker-admin
 User=printnanny
 RemainAfterExit=yes
-ExecStart=/var/lib/moonraker/.venv/bin/python3 /var/lib/moonraker/moonraker/moonraker.py -d ${MOONRAKER_DATA_PATH} -l ${MOONRAKER_LOG} -c ${MOONRAKER_CONFIG_FILE}"
+ExecStart=/var/lib/moonraker/.venv/bin/python3 /var/lib/moonraker/moonraker/moonraker.py -d "${MOONRAKER_DATA_PATH}" -l "${MOONRAKER_LOG}" -c "${MOONRAKER_CONFIG_FILE}"
 Restart=always
 RestartSec=10

--- a/meta-printnanny/recipes-core/octoprint-apps/files/octoprint.service
+++ b/meta-printnanny/recipes-core/octoprint-apps/files/octoprint.service
@@ -14,7 +14,7 @@ Environment=OCTOPRINT_BASEDIR=/var/lib/octoprint
 Environment=OCTOPRINT_VENV=/var/lib/octoprint/venv
 Environment=OCTOPRINT_CONFIG=/var/lib/printnanny/settings/octoprint/octoprint.yaml
 Environment=OCTOPRINT_PORT=5001
-ExecStart=/bin/bash -c "${OCTOPRINT_VENV}/bin/python -m octoprint serve \
+ExecStart=/bin/bash -c "${OCTOPRINT_VENV}"/bin/python -m octoprint serve \
     --host 127.0.0.1 \
     --config "${OCTOPRINT_CONFIG}" \
     --port "${OCTOPRINT_PORT}"

--- a/meta-printnanny/recipes-core/octoprint-apps/files/octoprint.service
+++ b/meta-printnanny/recipes-core/octoprint-apps/files/octoprint.service
@@ -14,7 +14,10 @@ Environment=OCTOPRINT_BASEDIR=/var/lib/octoprint
 Environment=OCTOPRINT_VENV=/var/lib/octoprint/venv
 Environment=OCTOPRINT_CONFIG=/var/lib/printnanny/settings/octoprint/octoprint.yaml
 Environment=OCTOPRINT_PORT=5001
-ExecStart=/bin/bash -c "${OCTOPRINT_VENV}"/bin/python -m octoprint serve \
+ExecStart=/bin/bash -c '"${OCTOPRINT_VENV}/bin/python" -m octoprint serve \
+    --host 127.0.0.1 \
+    --config "${OCTOPRINT_CONFIG}" \
+    --port "${OCTOPRINT_PORT}"'
     --host 127.0.0.1 \
     --config "${OCTOPRINT_CONFIG}" \
     --port "${OCTOPRINT_PORT}"

--- a/meta-printnanny/recipes-core/printnanny-cloud-apps/files/printnanny-cloud.target
+++ b/meta-printnanny/recipes-core/printnanny-cloud-apps/files/printnanny-cloud.target
@@ -1,7 +1,5 @@
 [Unit]
 Description=systemd unit to group all PrintNanny Cloud services
-
-[Service]
 Wants=printnanny-cloud-nats.service printnanny-cloud-sync.service
 
 [Install]


### PR DESCRIPTION
Observed while monitoring a boot via serial terminal:

```
[    5.317650] systemd[1]: /lib/systemd/system/printnanny-cloud.target:4: Unknown section 'Service'. Ignoring.
[    5.354162] systemd[1]: /lib/systemd/system/octoprint.service:20: Unbalanced quoting, ignoring: "/bin/bash -c "${OCTOPRINT_VENV}/bin/python -m octoprint serve      --host 127.0.0.1      --config "${OCTOPRINT_CONFIG}"      --port "${OCTOPRINT_PORT}""
[    5.376673] systemd[1]: octoprint.service: Unit configuration has fatal error, unit will not be started.
[    5.412569] systemd[1]: /lib/systemd/system/mainsail.target:4: Unknown section 'Service'. Ignoring.
[    5.425614] systemd[1]: /lib/systemd/system/moonraker.service:24: Unbalanced quoting, ignoring: "/var/lib/moonraker/.venv/bin/python3 /var/lib/moonraker/moonraker/moonraker.py -d ${MOONRAKER_DATA_PATH} -l ${MOONRAKER_LOG} -c ${MOONRAKER_CONFIG_FILE}""
[    5.448248] systemd[1]: moonraker.service: Unit configuration has fatal error, unit will not be started.
[    5.671229] systemd[1]: octoprint.service: Cannot add dependency job, ignoring: Unit octoprint.service has a bad unit file setting.
[    5.683804] systemd[1]: moonraker.service: Cannot add dependency job, ignoring: Unit moonraker.service has a bad unit file setting.
```