### PR TITLE
fix github suggestion artifact(?)

### DIFF
--- a/meta-printnanny/recipes-core/octoprint-apps/files/octoprint.service
+++ b/meta-printnanny/recipes-core/octoprint-apps/files/octoprint.service
@@ -18,9 +18,6 @@ ExecStart=/bin/bash -c '"${OCTOPRINT_VENV}/bin/python" -m octoprint serve \
     --host 127.0.0.1 \
     --config "${OCTOPRINT_CONFIG}" \
     --port "${OCTOPRINT_PORT}"'
-    --host 127.0.0.1 \
-    --config "${OCTOPRINT_CONFIG}" \
-    --port "${OCTOPRINT_PORT}"
 Restart=on-failure
 RestartSec=10
 IOSchedulingClass=realtime


### PR DESCRIPTION
This produced an invalid systemd unit that caused postinst failure during image build:

```
WARNING: printnanny-release-image-1.0-r0 do_rootfs: octoprint-apps.postinst returned 1, marking as unpacked only, configuration required on target.
ERROR: printnanny-release-image-1.0-r0 do_rootfs: Postinstall scriptlets of ['octoprint-apps'] have failed. If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget:${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.
Details of the failure are in /poky/build/tmp/work/raspberrypi4_64-bitsy-linux/printnanny-release-image/1.0-r0/temp/log.do_rootfs.
ERROR: Logfile of failure stored in: /poky/build/tmp/work/raspberrypi4_64-bitsy-linux/printnanny-release-image/1.0-r0/temp/log.do_rootfs.323
ERROR: Task (/poky/meta-bitsy/meta-printnanny/recipes-core/images/printnanny-release-image.bb:do_rootfs) failed with exit code '1'
```