### PR TITLE
Fix printnanny-gst-plugin package RDEPENDS

### DIFF
--- a/conf/distro/bitsy.conf
+++ b/conf/distro/bitsy.conf
@@ -29,28 +29,7 @@ MAINTAINER = "Leigh Johnson <leigh@bitsy.ai>"
 TARGET_VENDOR = "-bitsy"
 LOCALCONF_VERSION = "2"
 
-BITSY_DEFAULT_DISTRO_FEATURES = "\
-    acl \
-    argp \
-    bitsy-growpart \
-    bluetooth \
-    ext4 \
-    ipv4 \
-    ipv6 \
-    keyboard \
-    largefile \
-    overlayfs \
-    nginx \
-    seccomp \
-    swupdate \
-    systemd \
-    usbgadget \
-    usbhost \
-    vfat \
-    wifi \
-    xattrs \
-    zeroconf \
-"
+BITSY_DEFAULT_DISTRO_FEATURES = "acl argp bitsy-growpart overlayfs bluetooth ext4 ipv4 ipv6 keyboard largefile overlayfs nginx seccomp swupdate systemd usbgadget usbhost vfat wifi xattrs zeroconf"
 
 LICENSE = "AGPLv3"
 DESCRIPTION = "A console-only image with read-only root filesystem and writeable data partition"
@@ -58,10 +37,7 @@ DESCRIPTION = "A console-only image with read-only root filesystem and writeable
 BITSY_DEFAULT_EXTRA_RDEPENDS = ""
 
 BITSY_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
-DISTRO_FEATURES ??= "\
-    ${DISTRO_FEATURES_DEFAULT} \
-    ${BITSY_DEFAULT_DISTRO_FEATURES} \
-"
+DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${BITSY_DEFAULT_DISTRO_FEATURES}"
 
 # EXTRA_IMAGE_FEATURES += "ptest-pkgs"
 

--- a/meta-printnanny/conf/distro/printnanny.conf
+++ b/meta-printnanny/conf/distro/printnanny.conf
@@ -18,15 +18,9 @@ OS_RELEASE_FIELDS:printnanny = "\
     YOCTO_VERSION YOCTO_CODENAME SDK_VERSION VARIANT_NAME VARIANT_ID \
 "
 
-DISTRO_FEATURES = "\
-    ${DISTRO_FEATURES_DEFAULT} \
-    ${BITSY_DEFAULT_DISTRO_FEATURES} \
-    opencv \
-    opengl \
-    tensorflow \
-    tensorflow-lite \
-    polkit \
-"
+PRINTNANNY_DEFAULT_DISTRO_FEATURES = "acl argp bitsy-growpart bluetooth ext4 ipv4 ipv6 keyboard largefile overlayfs nginx seccomp swupdate systemd usbgadget usbhost vfat wifi xattrs zeroconf opencv opengl tensorflow tensorflow-lite polkit"
+
+DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${PRINTNANNY_DEFAULT_DISTRO_FEATURES}"
 
 FORTRAN:forcevariable = ",fortran"
 

--- a/meta-printnanny/conf/distro/printnanny.conf
+++ b/meta-printnanny/conf/distro/printnanny.conf
@@ -18,9 +18,8 @@ OS_RELEASE_FIELDS:printnanny = "\
     YOCTO_VERSION YOCTO_CODENAME SDK_VERSION VARIANT_NAME VARIANT_ID \
 "
 
-PRINTNANNY_DEFAULT_DISTRO_FEATURES = "acl argp bitsy-growpart bluetooth ext4 ipv4 ipv6 keyboard largefile overlayfs nginx seccomp swupdate systemd usbgadget usbhost vfat wifi xattrs zeroconf opencv opengl tensorflow tensorflow-lite polkit"
-
-DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${PRINTNANNY_DEFAULT_DISTRO_FEATURES}"
+PRINTNANNY_DISTRO_FEATURES = "opengl tensorflow tensorflow-lite polkit"
+DISTRO_FEATURES:append = " ${PRINTNANNY_DISTRO_FEATURES}"
 
 FORTRAN:forcevariable = ",fortran"
 

--- a/meta-printnanny/conf/layer.conf
+++ b/meta-printnanny/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "printnanny"
 BBFILE_PATTERN_printnanny = "^${LAYERDIR}/"
 BBFILE_PRIORITY_printnanny = "10"
 
-LAYERDEPENDS_printnanny = "bitsy core meta-initramfs yocto meta-microcontroller multimedia-layer networking-layer meta-python swupdate raspberrypi meta-tensorflow webserver"
+LAYERDEPENDS_printnanny = "bitsy core meta-initramfs yocto meta-microcontroller multimedia-layer networking-layer meta-python swupdate raspberrypi webserver"
 LAYERSERIES_COMPAT_printnanny = "kirkstone langdale"

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin.inc
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin.inc
@@ -38,3 +38,6 @@ RDEPENDS:${PN} += "\
     tensorflow-lite \
 "
 FILES:${PN} += "${datadir} ${bindir} ${libdir}/"
+
+# required to install nnstreamer-dev
+INSANE_SKIP:${PN} += "dev-deps"

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin.inc
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin.inc
@@ -1,9 +1,3 @@
-inherit pkgconfig 
-inherit systemd
-
-PREFERRED_VERSION:${PN}:tensorflow-lite-native = "2.9.1"
-PREFERRED_VERSION:${PN}:tensorflow-lite = "2.9.1"
-
 # copy LICENSE_FLAGS_ACCEPTED to local.conf
 LICENSE_FLAGS_ACCEPTED += "\
     commercial_gstreamer1.0-libav \

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin.inc
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin.inc
@@ -1,6 +1,9 @@
 inherit pkgconfig 
 inherit systemd
 
+PREFERRED_VERSION:${PN}:tensorflow-lite-native = "2.9.1"
+PREFERRED_VERSION:${PN}:tensorflow-lite = "2.9.1"
+
 # copy LICENSE_FLAGS_ACCEPTED to local.conf
 LICENSE_FLAGS_ACCEPTED += "\
     commercial_gstreamer1.0-libav \
@@ -16,9 +19,12 @@ DEPENDS += "openssl \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad \
-    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-plugins-ugly \   
+    nnstreamer \
+    tensorflow-lite \
 "
 RDEPENDS:${PN} += "\
+    glib-2.0 \
     gstreamer1.0 \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
@@ -27,6 +33,8 @@ RDEPENDS:${PN} += "\
     libcamera \
     libcamera-gst \
     nnstreamer \
+    nnstreamer-dev \
+    nnstreamer-tensorflow-lite \
     tensorflow-lite \
 "
-FILES:${PN} += "${datadir} ${bindir}"
+FILES:${PN} += "${datadir} ${bindir} ${libdir}/"

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
@@ -6,6 +6,9 @@ SRC_URI = "\
 "
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/AGPL-3.0-or-later;md5=a4af3f9f0c0fc9de318e4df46665906e"
 SRC_URI[sha256sum] = "78b8b9f15800aa5eeb75ad3e69c519b66cdd3e7ecbae910f69c2442b99fd3d9c"
+
+include printnanny-gst-plugin.inc
+
 do_install(){
     install -d "${D}${bindir}"
     install -d "${D}${libdir}/gstprintnanny"
@@ -17,4 +20,3 @@ do_install(){
 
 FILES:${PN} += "${libdir}/gstprintnanny ${bindir}/printnanny-gst-pipeline"
 
-include printnanny-gst-plugin.inc

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
@@ -17,11 +17,10 @@ do_install(){
 
 R = "1"
 
-PREFERRED_VERSION:${PN}:tensorflow-lite-native = "2.10.0"
-PREFERRED_VERSION:${PN}:tensorflow-lite = "2.10.0"
+PREFERRED_VERSION:${PN}:tensorflow-lite-native = "2.9.1"
+PREFERRED_VERSION:${PN}:tensorflow-lite = "2.9.1"
 
 SYSTEMD_AUTO_ENABLE = "enable"
-
 
 DEPENDS = "\
     gstreamer1.0 \
@@ -40,6 +39,7 @@ RDEPENDS:${PN} += "\
     libcamera \
     libcamera-gst \
     nnstreamer \
+    nnstreamer-dev \
     nnstreamer-tensorflow-lite \
     tensorflow-lite \
 "

--- a/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
+++ b/meta-printnanny/recipes-core/printnanny-gst-plugin/printnanny-gst-plugin_0.4.0.bb
@@ -15,33 +15,6 @@ do_install(){
     ln -sf ./gstreamer-1.0/libgstprintnanny.so ./libgstprintnanny.so
 }
 
-R = "1"
+FILES:${PN} += "${libdir}/gstprintnanny ${bindir}/printnanny-gst-pipeline"
 
-PREFERRED_VERSION:${PN}:tensorflow-lite-native = "2.9.1"
-PREFERRED_VERSION:${PN}:tensorflow-lite = "2.9.1"
-
-SYSTEMD_AUTO_ENABLE = "enable"
-
-DEPENDS = "\
-    gstreamer1.0 \
-    gstreamer1.0-plugins-base \
-    nnstreamer \
-    tensorflow-lite \
-"
-
-RDEPENDS:${PN} += "\
-    glib-2.0 \
-    gstreamer1.0 \
-    gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-plugins-bad \
-    gstreamer1.0-plugins-ugly \
-    libcamera \
-    libcamera-gst \
-    nnstreamer \
-    nnstreamer-dev \
-    nnstreamer-tensorflow-lite \
-    tensorflow-lite \
-"
-
-FILES:${PN} += "${libdir}/"
+include printnanny-gst-plugin.inc

--- a/meta-printnanny/recipes-nnstreamer/nnstreamer/nnstreamer_%.bbappend
+++ b/meta-printnanny/recipes-nnstreamer/nnstreamer/nnstreamer_%.bbappend
@@ -1,1 +1,2 @@
 DEPENDS += "tensorflow-lite"
+RDEPENDS:${PN} += "tensorflow-lite ${PN}-tensorflow-lite"


### PR DESCRIPTION
Fixes missing `/usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow2-lite.so` shared obj, which is causing `printnanny-vision.service` to fail with error `Cannot identify the given neural network framework, tensorflow2-lite`


```
pn-v0-4:~$ ls /usr/lib/nnstreamer/filters/
libnnstreamer_filter_cpp.so
```

```
Dec 01 14:36:59 pn-v0-4 printnanny-vision[1197]: [2022-12-01T22:36:59Z WARN  printnanny_gst_pipeline] octoprint compatibility enabled, writing hls segments/playlist to /var/run/printnanny-hls/segment%05d.ts /var/run/printnanny-hls/playlist.m3u8
Dec 01 14:36:59 pn-v0-4 printnanny-gst-[1197]: Cannot identify the given neural network framework, tensorflow2-lite
Dec 01 14:36:59 pn-v0-4 printnanny-vision[1197]: 0:00:03.773412720  1197   0x558ac0d670 WARN           basetransform gstbasetransform.c:1599:gst_base_transform_default_query:<tensorfilter0:sink> no caps can be handled by this pad
Dec 01 14:36:59 pn-v0-4 printnanny-vision[1197]: 0:00:03.774448331  1197   0x558ac0d670 WARN           basetransform gstbasetransform.c:1599:gst_base_transform_default_query:<tensorfilter0:sink> no caps can be handled by this pad
Dec 01 14:36:59 pn-v0-4 printnanny-vision[1197]: 0:00:03.774573202  1197   0x558ac0d670 WARN           basetransform gstbasetransform.c:1599:gst_base_transform_default_query:<tensorfilter0:sink> no caps can be handled by this pad
Dec 01 14:36:59 pn-v0-4 printnanny-vision[1197]: 0:00:03.775336313  1197   0x558ac0d670 WARN           basetransform gstbasetransform.c:1599:gst_base_transform_default_query:<tensorfilter0:sink> no caps can be handled by this pad
Dec 01 14:36:59 pn-v0-4 printnanny-vision[1197]: [2022-12-01T22:36:59Z ERROR printnanny_gst_pipeline] Error running pipeline: Failed to link elements 'capsfilter__tensor' and 'tensorfilter0'
```