### PR TITLE
Fix: libcamera missing USB camera pipeline/ipa module

### DIFF
--- a/recipes-multimedia/libcamera/libcamera_0.0.2.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.0.2.bb
@@ -36,7 +36,7 @@ EXTRA_OEMESON = " \
 
 EXTRA_OEMESON:raspberrypi4-64 = " \
     -Dpipelines=raspberrypi,uvcvideo \
-    -Dipas=raspberrypi \
+    -Dipas=raspberrypi,vimc \
     -Dv4l2=true \
     -Dcam=enabled \
     -Dlc-compliance=disabled \

--- a/recipes-multimedia/libcamera/libcamera_0.0.2.bb
+++ b/recipes-multimedia/libcamera/libcamera_0.0.2.bb
@@ -35,7 +35,7 @@ EXTRA_OEMESON = " \
 "
 
 EXTRA_OEMESON:raspberrypi4-64 = " \
-    -Dpipelines=raspberrypi \
+    -Dpipelines=raspberrypi,uvcvideo \
     -Dipas=raspberrypi \
     -Dv4l2=true \
     -Dcam=enabled \


### PR DESCRIPTION
ref: https://github.com/bitsy-ai/printnanny-os/issues/158