### PR TITLE
Create moonraker data dir in moonraker-venv service

### DIFF
--- a/meta-printnanny/recipes-3dprinter/moonraker/files/moonraker-venv.service
+++ b/meta-printnanny/recipes-3dprinter/moonraker/files/moonraker-venv.service
@@ -8,7 +8,10 @@ Requires=home.mount
 Type=oneshot
 SyslogIdentifier=moonraker-venv
 Environment=MOONRAKER_VENV=/home/printnanny/moonraker-venv
+Environment=MOONRAKER_DATA_PATH=/home/printnanny/.local/share/moonraker/
 ExecStart=/usr/bin/python3 -m venv --system-site-packages "${MOONRAKER_VENV}"
+ExecStart=/bin/bash -c "mkdir -p ${MOONRAKER_DATA_PATH}"
+
 User=printnanny
 
 [Install]

--- a/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-edge-nats.service
+++ b/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-edge-nats.service
@@ -13,7 +13,7 @@ Type=simple
 SyslogIdentifier=printnanny-nats
 LogsDirectory=printnanny
 RuntimeDirectory=printnanny-edge-nats
-Environment=PRINTNANNY_GST_CONFIG=/var/run/printnanny-edge-nats/printnanny-gst.toml
+Environment=RUST_LOG=info
 ExecStart=/bin/bash -c '/usr/bin/printnanny -v nats-edge-worker --subject="pi.$(hostname).>" --hostname $(hostname)'
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
Fixes the following error in Moonraker startup:
```
May 24 14:32:52 raspberrypi4-64 bash[457]: #################################################################
May 24 14:32:52 raspberrypi4-64 bash[457]: All Configuration Files:
May 24 14:32:52 raspberrypi4-64 bash[457]: /home/printnanny/.config/printnanny/vcs/moonraker/moonraker.conf
May 24 14:32:52 raspberrypi4-64 bash[457]: #################################################################
May 24 14:32:52 raspberrypi4-64 bash[457]: [moonraker.py:add_warning()] - Unable to create data path folder at /home/printnanny/.local/share/moonraker
May 24 14:32:52 raspberrypi4-64 bash[457]: [app.py:register_local_handler()] - Registering HTTP Endpoint: (GET) /server/info
```