### PR TITLE
FilamentManager OctoPrint plugin recipe

### DIFF
--- a/meta-printnanny/recipes-core/octoprint-apps/octoprint-apps.bb
+++ b/meta-printnanny/recipes-core/octoprint-apps/octoprint-apps.bb
@@ -36,7 +36,6 @@ DEPENDS = "${OCTOPRINT_USER}-user"
 # install python3-octoprint-nanny to system site-packages
 RDEPENDS:${PN} = "\
     python3-octoprint-nanny \
-    python3-filament-manager \
     python3-pip \
     python3-wheel \
     ${OCTOPRINT_USER}-user \

--- a/meta-printnanny/recipes-core/octoprint-apps/octoprint-apps.bb
+++ b/meta-printnanny/recipes-core/octoprint-apps/octoprint-apps.bb
@@ -36,6 +36,7 @@ DEPENDS = "${OCTOPRINT_USER}-user"
 # install python3-octoprint-nanny to system site-packages
 RDEPENDS:${PN} = "\
     python3-octoprint-nanny \
+    python3-filament-manager \
     python3-pip \
     python3-wheel \
     ${OCTOPRINT_USER}-user \

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-argon2-cffi-bindings_21.2.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-argon2-cffi-bindings_21.2.0.bb
@@ -22,3 +22,4 @@ inherit python_poetry_core
 do_compile:prepend(){
     export ARGON2_CFFI_USE_SSE2=0
 }
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-argon2-cffi_21.3.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-argon2-cffi_21.3.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/argon2-cffi-21.3.0"
 RDEPENDS:${PN} = "python3-argon2-cffi-bindings"
 
 inherit python_poetry_core
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-async-timeout_%.bbappend
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-async-timeout_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-backports.csv_1.0.7.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-backports.csv_1.0.7.bb
@@ -2,11 +2,11 @@ SUMMARY = "OctoPrint-FilamentManager"
 HOMEPAGE = "https://github.com/OllisGit/OctoPrint-FilamentManager"
 AUTHOR = "Sven Lohrmann <malnvenshorn@gmail.com>, Olli <ollisgit@gmail.com>"
 LICENSE = "BSD-2-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=4940c38d79bc5dca0630466d7c54b004"
+LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=f75037314c7c090e595924cde362259d"
 
 SRC_URI = "https://files.pythonhosted.org/packages/79/0c/d0eaa9380189a292121acab65199ac95b9209b45006ad8aa5266abd36943/backports.csv-1.0.7.tar.gz"
 SRC_URI[sha256sum] = "1277dfff73130b2e106bf3dd347adb3c5f6c4340882289d88f31240da92cbd6d"
 
-S = "${WORKDIR}/backports.csv"
+S = "${WORKDIR}/backports.csv-${PV}"
 
 inherit setuptools3

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-backports.csv_1.0.7.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-backports.csv_1.0.7.bb
@@ -1,0 +1,12 @@
+SUMMARY = "OctoPrint-FilamentManager"
+HOMEPAGE = "https://github.com/OllisGit/OctoPrint-FilamentManager"
+AUTHOR = "Sven Lohrmann <malnvenshorn@gmail.com>, Olli <ollisgit@gmail.com>"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4940c38d79bc5dca0630466d7c54b004"
+
+SRC_URI = "https://files.pythonhosted.org/packages/79/0c/d0eaa9380189a292121acab65199ac95b9209b45006ad8aa5266abd36943/backports.csv-1.0.7.tar.gz"
+SRC_URI[sha256sum] = "1277dfff73130b2e106bf3dd347adb3c5f6c4340882289d88f31240da92cbd6d"
+
+S = "${WORKDIR}/backports.csv"
+
+inherit setuptools3

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-blinker_1.5.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-blinker_1.5.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/blinker-1.5"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-cachelib_0.9.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-cachelib_0.9.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/cachelib-0.9.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-colorlog_6.7.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-colorlog_6.7.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/colorlog-6.7.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-commonmark_0.9.1.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-commonmark_0.9.1.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/commonmark-0.9.1"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-deprecated_1.2.13.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-deprecated_1.2.13.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/Deprecated-1.2.13"
 RDEPENDS:${PN} = "python3-wrapt"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-emoji_2.2.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-emoji_2.2.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/emoji-2.2.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-feedparser_6.0.10.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-feedparser_6.0.10.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/feedparser-6.0.10"
 RDEPENDS:${PN} = "python3-sgmllib3k"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-filament-manager_0.9.1.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-filament-manager_0.9.1.bb
@@ -4,11 +4,15 @@ AUTHOR = "Sven Lohrmann <malnvenshorn@gmail.com>, Olli <ollisgit@gmail.com>"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4940c38d79bc5dca0630466d7c54b004"
 
-SRC_URI = "https://github.com/bitsy-ai/OctoPrint-FilamentManager/zipball/fix-python-10-compat"
-SRC_URI[sha256sum] = "9e3e14f0e60be2c76360cc2488517c973bfb23f773e630095673274490648b49"
+SRC_URI = "https://github.com/bitsy-ai/OctoPrint-FilamentManager/zipball/fix-python-10-compat/bitsy-ai-OctoPrint-FilamentManager-a8f964a.zip"
+SRC_URI[sha256sum] = "4172af2873af1518b28d44adc9f0b9bccb4d9fcca435bc64b95cb68d1cc2f0b7"
 
-S = "${WORKDIR}/bitsy-ai-OctoPrint-FilamentManager"
+S = "${WORKDIR}/bitsy-ai-OctoPrint-FilamentManager-a8f964a"
 
-RDEPENDS:${PN} = "python3-backports.csv python3-uritools python3-sqlalchemy"
+DEPENDS = "python3-octoprint-native python3-pip-native"
+RDEPENDS:${PN} = "python3-pip python3-backports.csv python3-uritools python3-sqlalchemy python3-octoprint"
 
+# setuptools3_do_compile:prepend(){
+#      ${STAGING_BINDIR_NATIVE}/${PYTHON_PN}-native/${PYTHON_PN} -m pip install octoprint
+# }
 inherit setuptools3

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-filament-manager_0.9.1.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-filament-manager_0.9.1.bb
@@ -1,0 +1,14 @@
+SUMMARY = "OctoPrint-FilamentManager"
+HOMEPAGE = "https://github.com/OllisGit/OctoPrint-FilamentManager"
+AUTHOR = "Sven Lohrmann <malnvenshorn@gmail.com>, Olli <ollisgit@gmail.com>"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4940c38d79bc5dca0630466d7c54b004"
+
+SRC_URI = "https://github.com/bitsy-ai/OctoPrint-FilamentManager/zipball/fix-python-10-compat"
+SRC_URI[sha256sum] = "9e3e14f0e60be2c76360cc2488517c973bfb23f773e630095673274490648b49"
+
+S = "${WORKDIR}/bitsy-ai-OctoPrint-FilamentManager"
+
+RDEPENDS:${PN} = "python3-backports.csv python3-uritools python3-sqlalchemy"
+
+inherit setuptools3

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-filament-manager_0.9.1.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-filament-manager_0.9.1.bb
@@ -12,7 +12,4 @@ S = "${WORKDIR}/bitsy-ai-OctoPrint-FilamentManager-a8f964a"
 DEPENDS = "python3-octoprint-native python3-pip-native"
 RDEPENDS:${PN} = "python3-pip python3-backports.csv python3-uritools python3-sqlalchemy python3-octoprint"
 
-# setuptools3_do_compile:prepend(){
-#      ${STAGING_BINDIR_NATIVE}/${PYTHON_PN}-native/${PYTHON_PN} -m pip install octoprint
-# }
 inherit setuptools3

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-filament-manager_0.9.1.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-filament-manager_0.9.1.bb
@@ -2,7 +2,7 @@ SUMMARY = "OctoPrint-FilamentManager"
 HOMEPAGE = "https://github.com/OllisGit/OctoPrint-FilamentManager"
 AUTHOR = "Sven Lohrmann <malnvenshorn@gmail.com>, Olli <ollisgit@gmail.com>"
 LICENSE = "BSD-2-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=4940c38d79bc5dca0630466d7c54b004"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3e00ca6129dc8358315015204ab9fe15"
 
 SRC_URI = "https://github.com/bitsy-ai/OctoPrint-FilamentManager/zipball/fix-python-10-compat/bitsy-ai-OctoPrint-FilamentManager-a8f964a.zip"
 SRC_URI[sha256sum] = "4172af2873af1518b28d44adc9f0b9bccb4d9fcca435bc64b95cb68d1cc2f0b7"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-filetype_1.2.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-filetype_1.2.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/filetype-1.2.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-flask-assets_2.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-flask-assets_2.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/Flask-Assets-2.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-flask-babel_2.0.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-flask-babel_2.0.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/Flask-Babel-2.0.0"
 RDEPENDS:${PN} = "python3-pytz python3-flask python3-babel python3-jinja2"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-flask-limiter_2.7.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-flask-limiter_2.7.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/Flask-Limiter-2.7.0"
 RDEPENDS:${PN} = "python3-limits python3-flask python3-rich python3-typing-extensions"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-flask-login_0.6.2.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-flask-login_0.6.2.bb
@@ -14,3 +14,5 @@ S = "${WORKDIR}/Flask-Login-0.6.2"
 RDEPENDS:${PN} = "python3-flask python3-werkzeug"
 
 inherit setuptools3
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-flask_2.2.2.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-flask_2.2.2.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/Flask-2.2.2"
 RDEPENDS:${PN} = "python3-werkzeug python3-jinja2 python3-itsdangerous python3-click"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-frozendict_2.3.4.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-frozendict_2.3.4.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/frozendict-2.3.4"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-ifaddr_0.2.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-ifaddr_0.2.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/ifaddr-0.2.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-itsdangerous_2.1.2.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-itsdangerous_2.1.2.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/itsdangerous-2.1.2"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-limits_2.7.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-limits_2.7.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/limits-2.7.0"
 RDEPENDS:${PN} = "python3-deprecated python3-setuptools python3-packaging python3-typing-extensions"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-netaddr_0.8.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-netaddr_0.8.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/netaddr-0.8.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-netifaces_0.11.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-netifaces_0.11.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/netifaces-0.11.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-octoprint-filecheck_2021.2.23.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-octoprint-filecheck_2021.2.23.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/OctoPrint-FileCheck-2021.2.23"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-octoprint-firmwarecheck_2021.10.11.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-octoprint-firmwarecheck_2021.10.11.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/OctoPrint-FirmwareCheck-2021.10.11"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-octoprint-pisupport_2022.6.13.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-octoprint-pisupport_2022.6.13.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/OctoPrint-PiSupport-2022.6.13"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-octoprint_1.8.6.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-octoprint_1.8.6.bb
@@ -57,3 +57,5 @@ RDEPENDS:${PN} = "\
     python3-zipstream-ng"
 
 inherit setuptools3_legacy
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-passlib_1.7.4.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-passlib_1.7.4.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/passlib-1.7.4"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-pathvalidate_2.5.2.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-pathvalidate_2.5.2.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/pathvalidate-2.5.2"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-pkginfo_1.8.3.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-pkginfo_1.8.3.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/pkginfo-1.8.3"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-pylru_1.2.1.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-pylru_1.2.1.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/pylru-1.2.1"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-rich_12.6.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-rich_12.6.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/rich-12.6.0"
 RDEPENDS:${PN} = "python3-pygments python3-commonmark"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-sarge_0.1.7.post1.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-sarge_0.1.7.post1.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/sarge-0.1.7.post1"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3_legacy
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-sentry-sdk_1.10.1.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-sentry-sdk_1.10.1.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/sentry-sdk-1.10.1"
 RDEPENDS:${PN} = "python3-certifi"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-sgmllib3k_1.0.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-sgmllib3k_1.0.0.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/sgmllib3k-1.0.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-tornado_6.2.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-tornado_6.2.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/tornado-6.2"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-unidecode_1.3.6.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-unidecode_1.3.6.bb
@@ -14,3 +14,5 @@ S = "${WORKDIR}/Unidecode-1.3.6"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-uritools_2.2.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-uritools_2.2.0.bb
@@ -2,11 +2,11 @@ SUMMARY = "Python3 uritools"
 HOMEPAGE = "https://github.com/tkem/uritools"
 AUTHOR = "Thomas Kemmer"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=4940c38d79bc5dca0630466d7c54b004"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f26bb17a77ef0afdb242c384163bcaec"
 
 SRC_URI = "https://files.pythonhosted.org/packages/ab/1c/e9aa4a907806743298171510042447adc20cd5cf5b95436206a067e14496/uritools-2.2.0.tar.gz"
 SRC_URI[sha256sum] = "80e8e23cafad54fd85811b5d9ba0fc595d933f5727c61c3937945eec09f99e2b"
 
-S = "${WORKDIR}/uritools"
+S = "${WORKDIR}/uritools-${PV}"
 
 inherit setuptools3

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-uritools_2.2.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-uritools_2.2.0.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Python3 uritools"
+HOMEPAGE = "https://github.com/tkem/uritools"
+AUTHOR = "Thomas Kemmer"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4940c38d79bc5dca0630466d7c54b004"
+
+SRC_URI = "https://files.pythonhosted.org/packages/ab/1c/e9aa4a907806743298171510042447adc20cd5cf5b95436206a067e14496/uritools-2.2.0.tar.gz"
+SRC_URI[sha256sum] = "80e8e23cafad54fd85811b5d9ba0fc595d933f5727c61c3937945eec09f99e2b"
+
+S = "${WORKDIR}/uritools"
+
+inherit setuptools3

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-webassets_2.0.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-webassets_2.0.bb
@@ -13,3 +13,4 @@ S = "${WORKDIR}/webassets-2.0"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-websocket-client_1.4.2.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-websocket-client_1.4.2.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/websocket-client-1.4.2"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-werkzeug_2.2.2.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-werkzeug_2.2.2.bb
@@ -14,3 +14,5 @@ S = "${WORKDIR}/Werkzeug-2.2.2"
 RDEPENDS:${PN} = "python3-markupsafe"
 
 inherit setuptools3
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-zeroconf_0.39.4.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-zeroconf_0.39.4.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/zeroconf-0.39.4"
 RDEPENDS:${PN} = "python3-async-timeout python3-ifaddr"
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-printnanny/recipes-core/python3-octoprint/python3-zipstream-ng_1.3.4.bb
+++ b/meta-printnanny/recipes-core/python3-octoprint/python3-zipstream-ng_1.3.4.bb
@@ -14,3 +14,4 @@ S = "${WORKDIR}/zipstream-ng-1.3.4"
 RDEPENDS:${PN} = ""
 
 inherit setuptools3
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This recipe requires a full build for `python3-octoprint-native`, which is why I had to extend a ton of python3 packages to export a native build package.

This is because OctoPrint bundles a custom fork of setuptools, which needs to be installed on the native build system in order to cross-compile a binary wheel:
https://github.com/OllisGit/OctoPrint-FilamentManager/blob/master/setup.py#L25

I had previously hacked around this by vendoring OctoPrint's `octoprint_setuptools` module in my own plugin:
https://github.com/bitsy-ai/octoprint-nanny-plugin/blob/main/setup.py#L106

ref: https://github.com/bitsy-ai/printnanny-os/issues/193