### PR TITLE
fix: printnanny-cloud-sync.service start command

### DIFF
--- a/meta-printnanny/recipes-core/printnanny-cloud-apps/files/printnanny-cloud-sync.service
+++ b/meta-printnanny/recipes-core/printnanny-cloud-apps/files/printnanny-cloud-sync.service
@@ -17,7 +17,7 @@ StateDirectory=printnanny
 LogsDirectory=printnanny
 
 SyslogIdentifier=printnanny-cloud-sync
-ExecStart=/bin/sh -c '/usr/bin/printnanny -vv cloud sync || /usr/bin/printnanny -v nats-cloud-publisher pi.{pi_id}.status.boot --event-type=sync-settings-error && /usr/bin/printnanny -v nats-cloud-publisher pi.{pi_id}.status.boot --event-type=sync-settings-success'
+ExecStart=/usr/bin/printnanny -v cloud sync-models
 Restart=on-failure
 RestartSec=60
 User=printnanny


### PR DESCRIPTION
closes: https://github.com/bitsy-ai/printnanny-os/issues/222
