### PR TITLE
Provide blkid as runtime dependency for cloud-init 22.4

### DIFF
--- a/recipes-extended/cloud-init/cloud-init_22.4.2.bb
+++ b/recipes-extended/cloud-init/cloud-init_22.4.2.bb
@@ -61,6 +61,7 @@ DEPENDS += "\
 "
 
 RDEPENDS:${PN} = "\
+    util-linux-blkid \
     python3 \
     python3-certifi \
     python3-jinja2 \


### PR DESCRIPTION
ref: https://github.com/bitsy-ai/printnanny-os/issues/234