### PR TITLE
Fix: remove Wants=network-online.target dependency, keep After=network-online.target ordering

### DIFF
--- a/meta-printnanny/recipes-core/octoprint-apps/files/octoprint.service
+++ b/meta-printnanny/recipes-core/octoprint-apps/files/octoprint.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OctoPrint
-After=network-online.target octoprint-venv.service home.mount cloud-final.service printnanny-settings.service
-Wants=network-online.target octoprint-venv.service printnanny-settings.service
+After=network-online.target octoprint-venv.service home.mount printnanny-settings.service
+Wants=octoprint-venv.service printnanny-settings.service
 Requires=home.mount
 StartLimitInterval=60
 StartLimitBurst=3

--- a/meta-printnanny/recipes-core/printnanny-cloud-apps/files/printnanny-cloud-nats.service
+++ b/meta-printnanny/recipes-core/printnanny-cloud-apps/files/printnanny-cloud-nats.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=PrintNanny Cloud NATS worker
 After=network-online.target home.mount printnanny-init.service printnanny-settings.service
-Wants=network-online.target printnanny-init.service printnanny-settings.service
+Wants=printnanny-init.service printnanny-settings.service
 Requires=home.mount
 StartLimitInterval=60
 StartLimitBurst=3

--- a/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-edge-nats.service
+++ b/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-edge-nats.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=PrintNanny NATS worker
 After=network-online.target printnanny-init.service printnanny-settings.service
-Wants=network-online.target printnanny-init.service printnanny-settings.service
+Wants=printnanny-init.service printnanny-settings.service
 Requires=home.mount
 
 [Service]

--- a/meta-printnanny/recipes-core/printnanny-vision/files/printnanny-vision.service
+++ b/meta-printnanny/recipes-core/printnanny-vision/files/printnanny-vision.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=PrintNanny Cam Service
 After=network-online.target janus-gateway.service gstd.service
-Wants=network-online.target janus-gateway.service gstd.service
+Wants=janus-gateway.service gstd.service
 StartLimitInterval=60
 StartLimitBurst=3
 PartOf=printnanny-vision.target

--- a/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud-config.service
+++ b/meta-printnanny/recipes-extended/cloud-init/cloud-init/cloud-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target boot.mount var-lib-cloud.mount
-Wants=network-online.target cloud-config.target
+Wants=cloud-config.target
 Requires=boot.mount var-lib-cloud.mount
 
 [Service]

--- a/meta-printnanny/recipes-multimedia/janus-gateway/files/janus-gateway.service
+++ b/meta-printnanny/recipes-multimedia/janus-gateway/files/janus-gateway.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Janus WebRTC Gateway
 After=network-online.target nss-lookup.target
-Wants=network-online.target nss-lookup.target
+Wants=nss-lookup.target
 
 [Service]
 Type=simple

--- a/recipes-multimedia/janus-gateway/files/janus-gateway.service
+++ b/recipes-multimedia/janus-gateway/files/janus-gateway.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Janus WebRTC Gateway
 After=network-online.target nss-lookup.target avahi-daemon.service
-Wants=network-online.target nss-lookup.target avahi-daemon.service
+Wants=nss-lookup.target avahi-daemon.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Services with a `Wants=network-online.target` dependency are getting restarted when the network is unavailable. 

ref: https://github.com/bitsy-ai/printnanny-os/issues/282
