### PR TITLE
fix: cloud-init dep cycle

### DIFF
--- a/meta-printnanny/recipes-3dprinter/klipper/files/klipper.service
+++ b/meta-printnanny/recipes-3dprinter/klipper/files/klipper.service
@@ -2,9 +2,9 @@
 Description=Starts Klipper and provides klippy Unix Domain Socket API
 Documentation=https://www.klipper3d.org/
 BindsTo=mainsail.target
-After=network.target cloud-init.target printnanny-settings.service
+After=network-online.target printnanny-settings.service
 Before=moonraker.service
-Wants=udev.target cloud-init.target printnanny-settings.service
+Wants=udev.target printnanny-settings.service
 
 [Install]
 Alias=klippy.service

--- a/meta-printnanny/recipes-3dprinter/moonraker/files/moonraker.service
+++ b/meta-printnanny/recipes-3dprinter/moonraker/files/moonraker.service
@@ -2,7 +2,7 @@
 Description=Moonraker provides Web API for klipper
 Documentation=https://moonraker.readthedocs.io/en/latest/
 BindsTo=mainsail.target
-After=network.target home.mount cloud-init.target klipper.service mainsail.target printnanny-settings.service
+After=network-online.target home.mount klipper.service mainsail.target printnanny-settings.service
 Wants=printnanny-settings.service
 Requires=home.mount
 

--- a/meta-printnanny/recipes-core/octoprint/files/octoprint.service
+++ b/meta-printnanny/recipes-core/octoprint/files/octoprint.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OctoPrint
-After=network-online.target home.mount cloud-init.target printnanny-settings.service
-Wants=cloud-init.target printnanny-settings.service
+After=network-online.target home.mount printnanny-settings.service
+Wants=printnanny-settings.service
 Requires=home.mount
 StartLimitInterval=60
 StartLimitBurst=3

--- a/meta-printnanny/recipes-core/printnanny-cloud-apps/files/printnanny-cloud-sync.service
+++ b/meta-printnanny/recipes-core/printnanny-cloud-apps/files/printnanny-cloud-sync.service
@@ -23,4 +23,4 @@ RestartSec=60
 User=printnanny
 
 [Install]
-WantedBy=printnanny-cloud.target
+WantedBy=printnanny-cloud.target printnanny-online.target

--- a/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-edge-nats.service
+++ b/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-edge-nats.service
@@ -17,4 +17,4 @@ User=printnanny
 SupplementaryGroups=printnanny-admin
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target printnanny-online.target

--- a/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-init.service
+++ b/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-init.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=PrintNanny OS Initialization service
-After=cloud-init.target home.mount
-Requires=cloud-init.target home.mount
+After=home.mount
+Requires=home.mount
 
 [Service]
 Type=oneshot
@@ -11,3 +11,6 @@ ExecStart=/usr/bin/printnanny -vv init
 Restart=on-failure
 RestartSec=1
 User=printnanny
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-motd.service
+++ b/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-motd.service
@@ -12,4 +12,4 @@ Restart=on-failure
 RestartSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target printnanny-online.target

--- a/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-settings.service
+++ b/meta-printnanny/recipes-core/printnanny-core-apps/files/printnanny-settings.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=PrintNanny Settings Repo
 Before=multi-user.target
-After=cloud-init.target printnanny-init.service
-Wants=cloud-init.target printnanny-init.service
+After=network-online.target printnanny-init.service
+Wants=printnanny-init.service
 StartLimitInterval=60
 StartLimitBurst=3
 ConditionPathExists=!/home/printnanny/.config/printnanny/vcs

--- a/meta-printnanny/recipes-core/printnanny-dash/files/printnanny-dash.service
+++ b/meta-printnanny/recipes-core/printnanny-dash/files/printnanny-dash.service
@@ -15,4 +15,4 @@ RestartSec=10
 User=printnanny
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target printnanny-online.target

--- a/meta-printnanny/recipes-core/printnanny-rs/files/printnanny-snapshot.service
+++ b/meta-printnanny/recipes-core/printnanny-rs/files/printnanny-snapshot.service
@@ -16,4 +16,4 @@ RestartSec=10
 User=printnanny
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target printnanny-online.target

--- a/meta-printnanny/recipes-core/printnanny-vision/files/printnanny-vision.target
+++ b/meta-printnanny/recipes-core/printnanny-vision/files/printnanny-vision.target
@@ -3,4 +3,4 @@ Description=Systemd unit to group all PrintNanny Vision services
 Wants=gstd.service printnanny-vision.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target printnanny-online.target

--- a/meta-printnanny/recipes-extended/nats-server/files/printnanny-nats-server.service
+++ b/meta-printnanny/recipes-extended/nats-server/files/printnanny-nats-server.service
@@ -11,3 +11,6 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/nats-server --config /etc/nats-server/nats-server.conf
 Restart=always
 RestartSec=10
+
+[Install]
+WantedBy=multi-user.target printnanny-online.target


### PR DESCRIPTION
Fixes some ordering cycle issues:

```
May  8 00:58:51 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found ordering cycle on octoprint.service/start
May  8 00:58:51 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on cloud-init.target/start
May  8 00:58:51 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on cloud-final.service/start
May  8 00:58:51 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on multi-user.target/start
May  8 00:58:51 rpi4b4g-imx708 systemd[1]:  multi-user.target: Job octoprint.service/start deleted to break ordering cycle starting with multi-user.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found ordering cycle on mainsail.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on klipper.service/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on cloud-init.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on cloud-final.service/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on multi-user.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Job mainsail.target/start deleted to break ordering cycle starting with multi-user.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found ordering cycle on printnanny-edge-nats.service/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on printnanny-settings.service/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on cloud-init.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on cloud-final.service/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on multi-user.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Job printnanny-edge-nats.service/start deleted to break ordering cycle starting with multi-user.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found ordering cycle on printnanny-settings.service/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on cloud-init.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on cloud-final.service/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Found dependency on multi-user.target/start
May  8 00:58:52 rpi4b4g-imx708 systemd[1]:  multi-user.target: Job printnanny-settings.service/start deleted to break ordering cycle starting with multi-user.target/start
```